### PR TITLE
refactor: extract helper functions in main.go

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -30,24 +30,40 @@ func main() {
 		"regulated_mode", cfg.RegulatedMode,
 	)
 
-	// Initialize Prometheus metrics
 	m := metrics.New()
+	authSvc := initializeAuthService(m)
+	jwtValidator := initializeJWTService(cfg)
 
-	a := authService.NewService(
+	r := setupRouter(log, m)
+	registerRoutes(r, authSvc, jwtValidator, log, cfg, m)
+
+	srv := httpserver.New(cfg.Addr, r)
+	startServer(srv, log)
+	waitForShutdown(srv, log)
+}
+
+// initializeAuthService creates and configures the authentication service
+func initializeAuthService(m *metrics.Metrics) *authService.Service {
+	return authService.NewService(
 		authStore.NewInMemoryUserStore(),
 		authStore.NewInMemorySessionStore(),
 		24*time.Hour, // TODO Make configurable
 		authService.WithMetrics(m),
 	)
+}
 
-	// Initialize JWT service and adapter for auth middleware
+// initializeJWTService creates and configures the JWT service and validator
+func initializeJWTService(cfg *config.Config) jwttoken.TokenValidator {
 	jwtService := jwttoken.NewJWTService(
 		cfg.JWTSigningKey,
 		"id-gateway",
 		"id-gateway-client",
 	)
-	jwtValidator := jwttoken.NewJWTServiceAdapter(jwtService)
+	return jwttoken.NewJWTServiceAdapter(jwtService)
+}
 
+// setupRouter creates a new router and configures common middleware
+func setupRouter(log logger.Logger, m *metrics.Metrics) *chi.Mux {
 	r := chi.NewRouter()
 
 	// Add Prometheus metrics endpoint (no auth required)
@@ -61,7 +77,19 @@ func main() {
 	r.Use(middleware.ContentTypeJSON)
 	r.Use(middleware.LatencyMiddleware(m))
 
-	authHandler := httptransport.NewAuthHandler(a, log, cfg.RegulatedMode, m)
+	return r
+}
+
+// registerRoutes registers all application routes and handlers
+func registerRoutes(
+	r *chi.Mux,
+	authSvc *authService.Service,
+	jwtValidator jwttoken.TokenValidator,
+	log logger.Logger,
+	cfg *config.Config,
+	m *metrics.Metrics,
+) {
+	authHandler := httptransport.NewAuthHandler(authSvc, log, cfg.RegulatedMode, m)
 
 	// Public auth endpoints (no JWT required)
 	r.Post("/auth/authorize", authHandler.HandleAuthorize)
@@ -72,10 +100,11 @@ func main() {
 		r.Use(middleware.RequireAuth(jwtValidator, log))
 		r.Get("/auth/userinfo", authHandler.HandleUserInfo)
 	})
+}
 
-	srv := httpserver.New(cfg.Addr, r)
-
-	log.Info("starting http server", "addr", cfg.Addr)
+// startServer starts the HTTP server in a goroutine
+func startServer(srv *http.Server, log logger.Logger) {
+	log.Info("starting http server", "addr", srv.Addr)
 
 	go func() {
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
@@ -83,8 +112,10 @@ func main() {
 			os.Exit(1)
 		}
 	}()
+}
 
-	// Graceful shutdown on SIGINT
+// waitForShutdown waits for an interrupt signal and gracefully shuts down the server
+func waitForShutdown(srv *http.Server, log logger.Logger) {
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, os.Interrupt)
 	<-quit


### PR DESCRIPTION
Extract common setup logic into clearly named helper functions:
- initializeAuthService: creates auth service with stores
- initializeJWTService: creates JWT service and validator
- setupRouter: configures router and common middleware
- registerRoutes: registers all application routes
- startServer: starts HTTP server in goroutine
- waitForShutdown: handles graceful shutdown

This makes main() more readable and easier to maintain as more
handlers and services are added.