### PR TITLE
Refactor auth handler responsibilities

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -116,7 +116,7 @@ func registerRoutes(
 	cfg *config.Server,
 	m *metrics.Metrics,
 ) {
-	authHandler := authHandler.New(authSvc, log, cfg.RegulatedMode, m)
+	authHandler := authHandler.New(authSvc, log, cfg.RegulatedMode)
 	consentSvc := consentService.NewService(
 		consentStore.NewInMemoryStore(),
 		audit.NewPublisher(audit.NewInMemoryStore()),

--- a/internal/auth/handler/mocks/auth-mocks.go
+++ b/internal/auth/handler/mocks/auth-mocks.go
@@ -14,7 +14,6 @@ import (
 	models "credo/internal/auth/models"
 	reflect "reflect"
 
-	uuid "github.com/google/uuid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -73,7 +72,7 @@ func (mr *MockAuthServiceMockRecorder) Token(ctx, req any) *gomock.Call {
 }
 
 // UserInfo mocks base method.
-func (m *MockAuthService) UserInfo(ctx context.Context, sessionID uuid.UUID) (*models.UserInfoResult, error) {
+func (m *MockAuthService) UserInfo(ctx context.Context, sessionID string) (*models.UserInfoResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UserInfo", ctx, sessionID)
 	ret0, _ := ret[0].(*models.UserInfoResult)

--- a/internal/auth/integration_test.go
+++ b/internal/auth/integration_test.go
@@ -48,7 +48,7 @@ func SetupSuite(t *testing.T) (*chi.Mux, *store.InMemoryUserStore, *store.InMemo
 	)
 
 	router := chi.NewRouter()
-	authHandler := auth.New(authService, logger, false, nil)
+	authHandler := auth.New(authService, logger, false)
 
 	// Public endpoints (no auth required) - mirrors production setup
 	router.Post("/auth/authorize", authHandler.HandleAuthorize)


### PR DESCRIPTION
## Summary
- simplify the auth HTTP handler by delegating session validation and metrics concerns to the service layer
- validate session identifiers and increment token metrics inside the auth service
- update HTTP handler wiring, mocks, and tests to match the service responsibilities

## Testing
- go test ./internal/auth/... -count=1
- go test ./cmd/... -count=1

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ae6b3bd488328beb551415851f2c7)