### PR TITLE
Add OAuth2 demo suite with true browser redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,21 @@ The project includes demo web interfaces:
 
 https://abramin.github.io/Credo/
 
-See [Frontend Readme](frontend/README.md) for details.
+### OAuth2 Demo Suite
+
+A comprehensive OAuth2 authorization code flow demo with true browser redirects:
+
+- **Demo Home**: http://localhost:3000/demo/index.html
+- **Authorization Flow**: `/demo/authorize.html` → `/demo/callback.html`
+- **Session Management**: `/demo/sessions.html`
+- **Token Lifecycle**: `/demo/tokens.html`
+- **Admin Operations**: `/demo/admin.html`
+
+See [OAuth Demo README](frontend/OAUTH_DEMO_README.md) for complete walkthrough.
+
+### Other Demos
+
+See [Frontend Readme](frontend/README.md) for details on other demo interfaces.
 
 ## Testing
 

--- a/frontend/OAUTH_DEMO_README.md
+++ b/frontend/OAUTH_DEMO_README.md
@@ -1,0 +1,427 @@
+# OAuth2 Demo Suite - Walkthrough Guide
+
+This guide explains how to use the Credo OAuth2 demo pages to understand and test the complete OAuth2 authorization code flow.
+
+## Overview
+
+The demo suite consists of separate HTML pages that demonstrate a realistic OAuth2 authorization code flow with:
+
+- **True browser redirects** (not simulated)
+- **Separate pages** for authorization and callback
+- **Explicit token exchange** requiring user action
+- **Visible session and token lifecycle controls**
+- **Raw API responses** for debugging
+
+## Architecture
+
+```
+┌─────────────────┐
+│  /demo/index    │  Landing page with links to all demos
+└────────┬────────┘
+         │
+         v
+┌─────────────────┐     redirect      ┌─────────────────┐
+│ /demo/authorize │ ─────────────────> │ /demo/callback  │
+└─────────────────┘   with code+state  └────────┬────────┘
+                                                 │
+                                                 v
+                                        ┌────────────────┐
+                                        │  Access Token  │
+                                        └───┬────────┬───┘
+                                            │        │
+                              ┌─────────────┘        └──────────────┐
+                              v                                     v
+                      ┌──────────────┐                    ┌─────────────┐
+                      │/demo/sessions│                    │/demo/tokens │
+                      └──────────────┘                    └─────────────┘
+```
+
+## Demo Pages
+
+### 1. Authorization Request (`/demo/authorize.html`)
+
+**Purpose**: Initiate the OAuth2 authorization code flow
+
+**How to use**:
+1. Open http://localhost:3000/demo/authorize.html (or your demo URL)
+2. Fill in the form:
+   - **Email**: `alice@example.com` (or any demo user)
+   - **Client ID**: `demo-client` (pre-filled)
+   - **Redirect URI**: Auto-filled to callback page
+   - **State**: Random value for CSRF protection (pre-generated)
+   - **Scopes**: Select `openid` and/or `profile`
+3. Click **"Authorize"**
+4. You will be **redirected** to the callback page
+
+**What happens**:
+```http
+POST /auth/authorize
+Content-Type: application/json
+
+{
+  "email": "alice@example.com",
+  "client_id": "demo-client",
+  "redirect_uri": "http://localhost:3000/demo/callback.html",
+  "state": "demo-state-abc123",
+  "scopes": ["openid", "profile"]
+}
+
+Response 200 OK:
+{
+  "code": "authz_...",
+  "redirect_uri": "http://localhost:3000/demo/callback.html?code=authz_...&state=demo-state-abc123"
+}
+```
+
+The page then performs `window.location.href = redirect_uri` - a **real redirect**.
+
+### 2. OAuth Callback (`/demo/callback.html`)
+
+**Purpose**: Receive authorization code and exchange for tokens
+
+**How to use**:
+1. This page automatically loads after redirect from authorize
+2. You'll see:
+   - The **authorization code** from URL query params
+   - The **state** parameter echoed back
+3. Review the received parameters
+4. Click **"Exchange Code for Tokens"**
+5. View the token response with:
+   - Raw JSON response
+   - Decoded access token (JWT claims)
+   - Decoded ID token (JWT claims)
+   - Token expiry information
+
+**What happens**:
+```http
+POST /auth/token
+Content-Type: application/json
+
+{
+  "grant_type": "authorization_code",
+  "code": "authz_...",
+  "redirect_uri": "http://localhost:3000/demo/callback.html",
+  "client_id": "demo-client"
+}
+
+Response 200 OK:
+{
+  "access_token": "eyJhbGci...",
+  "id_token": "eyJhbGci...",
+  "expires_in": 3600000000000,
+  "token_type": "Bearer"
+}
+```
+
+Tokens are stored in `sessionStorage` for use in other demo pages.
+
+### 3. Session Management (`/demo/sessions.html`)
+
+**Purpose**: View and manage active user sessions
+
+**How to use**:
+1. Paste your access token (or it auto-loads from previous step)
+2. Click **"Load Sessions"**
+3. View table of active sessions:
+   - Device information
+   - Location
+   - Created/last seen timestamps
+   - Current session indicator
+4. Actions:
+   - **Revoke** individual sessions
+   - **Logout All Other Sessions**
+
+**Note**: Session management endpoints may not be fully implemented yet. The page will show a helpful error message explaining the expected API contract.
+
+**Expected API**:
+```http
+GET /auth/sessions
+Authorization: Bearer {access_token}
+
+Response 200 OK:
+{
+  "sessions": [
+    {
+      "id": "uuid",
+      "device": "Chrome on macOS",
+      "location": "San Francisco, CA",
+      "created_at": "2025-12-13T10:00:00Z",
+      "last_seen": "2025-12-13T11:30:00Z",
+      "is_current": true
+    }
+  ]
+}
+```
+
+### 4. Token Lifecycle (`/demo/tokens.html`)
+
+**Purpose**: Manage token lifecycle - analyze, refresh, and revoke
+
+**How to use**:
+1. Paste your access token (or it auto-loads from previous step)
+2. Click **"Analyze Token"** to see:
+   - Subject, issuer, issued/expiry dates
+   - Live countdown timer until expiry
+   - Full JWT claims
+3. Try token operations:
+   - **Refresh Token**: Get new access token (requires refresh token)
+   - **Revoke Token**: Invalidate current token
+
+**Note**: Refresh and revocation endpoints may not be fully implemented yet. The page shows API contracts and gracefully handles missing endpoints.
+
+### 5. Admin Operations (`/demo/admin.html`)
+
+**Purpose**: Demonstrate admin-level destructive operations
+
+**⚠️ WARNING**: This page performs destructive operations!
+
+**How to use**:
+1. Enter **Admin API Token** (from `ADMIN_API_TOKEN` env var)
+2. Click **"Test Authentication"** to verify token
+3. Enter **User ID** (UUID) to delete
+4. Click **"Delete User"**
+5. Review confirmation checklist:
+   - User data will be permanently deleted
+   - All sessions will be revoked
+   - All refresh tokens will be invalidated
+   - Action cannot be undone
+6. Check all boxes and click **"⚠️ Confirm Deletion"**
+
+**What happens**:
+```http
+DELETE /admin/auth/users/{user_id}
+X-Admin-Token: {admin_token}
+
+Response 204 No Content (success)
+```
+
+This exercises PRD-001B flows for user deletion.
+
+## Complete Walkthrough
+
+### Basic OAuth Flow
+
+1. **Start**: Navigate to http://localhost:3000/demo/index.html
+2. **Click**: "▶ Start Authorization Flow" button
+3. **Authorize**: Fill form (use `alice@example.com`) and click "Authorize"
+4. **Redirect**: Browser automatically redirects to callback page
+5. **Exchange**: Click "Exchange Code for Tokens"
+6. **Review**: Examine decoded JWT claims and expiry
+
+### Session Management Flow
+
+1. **Complete** the basic OAuth flow above
+2. **Navigate**: Click "Manage tokens (refresh, revoke)" link
+3. **Or go to**: http://localhost:3000/demo/sessions.html
+4. **Load**: Sessions list (token auto-loaded from sessionStorage)
+5. **Manage**: Revoke individual sessions or logout all others
+
+### Token Lifecycle Flow
+
+1. **Complete** the basic OAuth flow
+2. **Navigate**: http://localhost:3000/demo/tokens.html
+3. **Analyze**: View token metadata and expiry countdown
+4. **Refresh**: Try refreshing the access token (if backend supports)
+5. **Revoke**: Revoke token to logout
+
+### Admin Flow
+
+1. **Get**: Admin token from environment variable
+2. **Navigate**: http://localhost:3000/demo/admin.html
+3. **Authenticate**: Paste admin token and test
+4. **Delete**: Enter user UUID and complete deletion workflow
+
+## Key Differences from Legacy Demo
+
+The new demo suite (`/demo/*`) differs from the legacy demo (`/demo.html`) in important ways:
+
+| Feature | Legacy Demo | New Demo Suite |
+|---------|-------------|----------------|
+| **Redirect** | Simulated (fake) | Real browser redirect |
+| **Pages** | Single page | Separate authorize & callback |
+| **State** | Shared Alpine.js state | No shared state between pages |
+| **Token storage** | Component scope only | sessionStorage |
+| **OAuth semantics** | Simplified | Production-like |
+| **Debugging** | Hidden details | All responses visible |
+
+## Technical Details
+
+### Stack
+
+- **HTML**: Plain HTML5, no templating
+- **CSS**: Tailwind CSS (CDN)
+- **JS**: Alpine.js (CDN) + vanilla JS
+- **Storage**: sessionStorage (page refresh clears state)
+- **Routing**: None - each page is separate
+
+### Shared Helpers
+
+All pages use `/js/oauth-helpers.js` for common functions:
+
+- `getAPIBase()` - Determine API URL based on environment
+- `decodeJWT(token)` - Decode JWT and add readable timestamps
+- `apiRequest(endpoint, options)` - Consistent fetch wrapper
+- `formatExpiry(nanoseconds)` - Format expiry time
+- `generateState()` - CSRF state generator
+- `getStoredTokens()` / `storeTokens()` - sessionStorage helpers
+
+### API Base URL Detection
+
+The demos automatically detect the correct API base URL:
+
+```javascript
+function getAPIBase() {
+  if (window.location.port === "3000") {
+    return "/api";  // Docker nginx proxy
+  }
+  if (window.location.hostname === "localhost") {
+    return "http://localhost:8080";  // Direct backend
+  }
+  return "";  // Same origin
+}
+```
+
+### State Management
+
+- **No persistence**: Page refresh clears all state
+- **sessionStorage**: Used only for passing tokens between demo pages
+- **No localStorage**: Explicitly avoided per requirements
+- **Alpine.js scope**: Each page has isolated Alpine component
+
+## Debugging Tips
+
+### View Raw Responses
+
+All demo pages show:
+- Raw JSON responses
+- HTTP status codes
+- Request/response bodies
+- Error details
+
+### Browser DevTools
+
+Open DevTools to see:
+- Network tab: All HTTP requests
+- Console: Any JavaScript errors
+- Application tab: sessionStorage contents
+
+### Common Issues
+
+**Authorization fails with redirect error**:
+- Check `ALLOWED_REDIRECT_SCHEMES` environment variable
+- Ensure redirect URI uses allowed scheme (http/https)
+
+**Token exchange fails**:
+- Verify authorization code wasn't already used
+- Check that redirect_uri matches exactly
+- Confirm code hasn't expired (10 minute TTL)
+
+**Session/token pages show "not implemented"**:
+- These endpoints may not exist in current backend
+- Pages show expected API contracts for reference
+- Safe to ignore if testing basic OAuth flow
+
+## Environment Variables
+
+Required for demo functionality:
+
+```bash
+# Backend
+ID_GATEWAY_ADDR=":8080"
+REGULATED_MODE="false"
+ALLOWED_REDIRECT_SCHEMES="http,https"  # Important!
+
+# Admin operations
+ADMIN_API_TOKEN="your-secret-admin-token"
+
+# JWT
+JWT_SIGNING_KEY="your-secret-key"
+JWT_ISSUER="http://localhost:8080"
+TOKEN_TTL="15m"
+SESSION_TTL="24h"
+```
+
+## Running the Demo
+
+### Docker Compose (Recommended)
+
+```bash
+# From project root
+docker-compose -f docker-compose.demo.yml up
+
+# Access demos at:
+# http://localhost:3000/demo/index.html
+```
+
+### Local Development
+
+```bash
+# Terminal 1: Run backend
+cd cmd/server
+go run main.go
+
+# Terminal 2: Serve frontend
+cd frontend/public
+python3 -m http.server 3000
+
+# Access demos at:
+# http://localhost:3000/demo/index.html
+```
+
+## Testing Checklist
+
+Use this checklist to verify all functionality:
+
+- [ ] Authorization initiates and redirects correctly
+- [ ] Callback receives code and state parameters
+- [ ] Code exchange returns valid JWT tokens
+- [ ] Access token decodes and shows claims
+- [ ] ID token decodes and shows user info
+- [ ] Token expiry countdown updates live
+- [ ] Session page loads or shows "not implemented"
+- [ ] Token page loads or shows "not implemented"
+- [ ] Admin authentication works with valid token
+- [ ] Admin user deletion requires confirmation
+- [ ] All pages show raw JSON responses
+- [ ] Error messages are clear and helpful
+
+## Non-Goals
+
+This demo explicitly does NOT include:
+
+- ❌ SPA routing or client-side navigation
+- ❌ localStorage for token persistence
+- ❌ PKCE (Proof Key for Code Exchange)
+- ❌ Refresh token storage outside memory
+- ❌ Production-grade styling or UX polish
+- ❌ Mock data or fake responses
+- ❌ OAuth client registration
+- ❌ Multi-tenancy
+
+## Future Enhancements
+
+Potential additions (not currently implemented):
+
+- Session management backend endpoints
+- Token refresh endpoint
+- Token revocation endpoint
+- Consent management integration
+- Device flow demonstration
+- Client credentials flow
+- OpenID Connect discovery
+
+## Support
+
+For issues or questions:
+
+1. Check browser console for errors
+2. Review "Raw API Response" sections in demo pages
+3. Verify environment variables are set correctly
+4. Check backend logs for detailed error messages
+
+## References
+
+- **PRD-001**: OAuth2 and OpenID Connect implementation
+- **PRD-001B**: User lifecycle and deletion flows
+- OAuth 2.0 RFC 6749: https://tools.ietf.org/html/rfc6749
+- OpenID Connect Core: https://openid.net/specs/openid-connect-core-1_0.html

--- a/frontend/public/demo/admin.html
+++ b/frontend/public/demo/admin.html
@@ -1,0 +1,448 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Admin Operations - Credo Demo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="/js/oauth-helpers.js"></script>
+    <script
+      defer
+      src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"
+    ></script>
+    <link rel="stylesheet" href="/css/styles.css" />
+  </head>
+  <body class="bg-gray-50 min-h-screen">
+    <div
+      style="
+        background: #fee;
+        color: #c00;
+        padding: 10px;
+        font-size: 14px;
+        border-bottom: 2px solid #c00;
+        text-align: center;
+        font-weight: bold;
+      "
+    >
+      ⚠️ ADMIN PANEL - DESTRUCTIVE OPERATIONS - DEMO ENVIRONMENT ONLY
+    </div>
+
+    <!-- Navigation -->
+    <nav class="bg-white shadow-sm border-b border-red-200">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="flex justify-between items-center h-16">
+          <div class="flex items-center">
+            <h1 class="text-xl font-bold text-red-900">
+              🔒 Admin Operations
+            </h1>
+          </div>
+          <div class="flex items-center space-x-4">
+            <a
+              href="/demo/index.html"
+              class="text-sm text-blue-600 hover:text-blue-800 font-medium"
+              >← Demo Home</a
+            >
+            <a
+              href="/index.html"
+              class="text-sm text-gray-600 hover:text-gray-900"
+              >User Portal</a
+            >
+          </div>
+        </div>
+      </div>
+    </nav>
+
+    <main
+      class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8"
+      x-data="adminPanel()"
+    >
+      <!-- Warning Banner -->
+      <div class="bg-red-50 border-2 border-red-400 rounded-lg p-6 mb-6">
+        <h2 class="text-lg font-bold text-red-900 mb-2 flex items-center">
+          <span class="text-2xl mr-2">⚠️</span>
+          ADMIN - DESTRUCTIVE ACTIONS
+        </h2>
+        <p class="text-sm text-red-800 mb-2">
+          This panel allows you to perform administrative operations that
+          <strong>permanently delete data</strong>.
+        </p>
+        <ul class="text-xs text-red-700 space-y-1 list-disc list-inside">
+          <li>User deletion removes all user data</li>
+          <li>All sessions for the user are revoked</li>
+          <li>All refresh tokens are deleted</li>
+          <li>These operations cannot be undone</li>
+        </ul>
+      </div>
+
+      <!-- Admin Token Input -->
+      <div class="bg-white rounded-lg shadow-md p-6 mb-6">
+        <h3 class="text-lg font-bold text-gray-900 mb-4">
+          Admin Authentication
+        </h3>
+        <div class="space-y-3">
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-2"
+              >Admin API Token</label
+            >
+            <input
+              type="password"
+              x-model="adminToken"
+              placeholder="Enter admin token (X-Admin-Token header)"
+              class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500 font-mono text-sm"
+            />
+            <p class="text-xs text-gray-500 mt-1">
+              Required for all admin operations. Set via ADMIN_API_TOKEN
+              environment variable.
+            </p>
+          </div>
+          <div class="flex gap-2">
+            <button
+              @click="testAuth"
+              :disabled="!adminToken || loading"
+              class="bg-gray-600 text-white px-4 py-2 rounded-md hover:bg-gray-700 disabled:bg-gray-400 disabled:cursor-not-allowed text-sm"
+            >
+              Test Authentication
+            </button>
+            <button
+              @click="clearAuth"
+              class="bg-gray-200 text-gray-700 px-4 py-2 rounded-md hover:bg-gray-300 text-sm"
+            >
+              Clear Token
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Error Display -->
+      <div
+        x-show="error"
+        class="bg-red-50 border border-red-200 rounded-lg p-4 mb-6"
+      >
+        <div class="flex items-start">
+          <div class="flex-1">
+            <h4 class="text-sm font-bold text-red-900 mb-1">Error</h4>
+            <p class="text-sm text-red-800" x-text="error"></p>
+          </div>
+          <button @click="error = null" class="text-red-600 hover:text-red-800">
+            ✕
+          </button>
+        </div>
+      </div>
+
+      <!-- Success Message -->
+      <div
+        x-show="success"
+        class="bg-green-50 border border-green-200 rounded-lg p-4 mb-6"
+      >
+        <div class="flex items-start">
+          <div class="flex-1">
+            <h4 class="text-sm font-bold text-green-900 mb-1">Success</h4>
+            <p class="text-sm text-green-800" x-text="success"></p>
+          </div>
+          <button
+            @click="success = null"
+            class="text-green-600 hover:text-green-800"
+          >
+            ✕
+          </button>
+        </div>
+      </div>
+
+      <!-- Delete User Operation -->
+      <div class="bg-white rounded-lg shadow-md p-6 mb-6">
+        <h3 class="text-lg font-bold text-gray-900 mb-4">Delete User</h3>
+
+        <div class="space-y-4">
+          <div class="bg-yellow-50 border border-yellow-200 rounded p-3">
+            <h4 class="text-sm font-bold text-yellow-900 mb-1">
+              What happens when you delete a user?
+            </h4>
+            <ul class="text-xs text-yellow-800 space-y-1 list-disc list-inside">
+              <li>User record is permanently deleted from the database</li>
+              <li>All active sessions are revoked</li>
+              <li>All refresh tokens are invalidated</li>
+              <li>User will be immediately logged out from all devices</li>
+              <li>User data export is <strong>not</strong> automatically performed (must be done separately per PRD-001B)</li>
+            </ul>
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-2"
+              >User ID (UUID)</label
+            >
+            <input
+              type="text"
+              x-model="deleteUserId"
+              placeholder="e.g., 123e4567-e89b-12d3-a456-426614174000"
+              class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500 font-mono text-sm"
+            />
+            <p class="text-xs text-gray-500 mt-1">
+              Enter the UUID of the user to delete
+            </p>
+          </div>
+
+          <!-- Confirmation Checklist -->
+          <div
+            x-show="showConfirmation"
+            class="bg-red-50 border border-red-300 rounded p-4"
+          >
+            <h4 class="text-sm font-bold text-red-900 mb-2">
+              ⚠️ Confirmation Required
+            </h4>
+            <p class="text-xs text-red-800 mb-3">
+              Please confirm you understand the consequences:
+            </p>
+            <div class="space-y-2">
+              <label class="flex items-start text-xs">
+                <input
+                  type="checkbox"
+                  x-model="confirmChecks.dataDeleted"
+                  class="mr-2 mt-0.5"
+                />
+                <span
+                  >I understand this will permanently delete the user
+                  record</span
+                >
+              </label>
+              <label class="flex items-start text-xs">
+                <input
+                  type="checkbox"
+                  x-model="confirmChecks.sessionsRevoked"
+                  class="mr-2 mt-0.5"
+                />
+                <span>I understand all sessions will be revoked</span>
+              </label>
+              <label class="flex items-start text-xs">
+                <input
+                  type="checkbox"
+                  x-model="confirmChecks.cannotUndo"
+                  class="mr-2 mt-0.5"
+                />
+                <span
+                  >I understand this action <strong>cannot be undone</strong></span
+                >
+              </label>
+            </div>
+          </div>
+
+          <div class="flex gap-2">
+            <button
+              x-show="!showConfirmation"
+              @click="showConfirmation = true"
+              :disabled="!adminToken || !deleteUserId || loading"
+              class="bg-red-600 text-white px-4 py-2 rounded-md hover:bg-red-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+            >
+              Delete User
+            </button>
+            <button
+              x-show="showConfirmation"
+              @click="executeDeleteUser"
+              :disabled="!allConfirmed() || loading"
+              class="bg-red-700 text-white px-4 py-2 rounded-md hover:bg-red-800 disabled:bg-gray-400 disabled:cursor-not-allowed"
+            >
+              <span x-show="!loading">⚠️ Confirm Deletion</span>
+              <span x-show="loading">
+                <span class="spinner"></span>
+                Deleting...
+              </span>
+            </button>
+            <button
+              x-show="showConfirmation"
+              @click="cancelDelete"
+              :disabled="loading"
+              class="bg-gray-200 text-gray-700 px-4 py-2 rounded-md hover:bg-gray-300"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Raw API Response -->
+      <div
+        x-show="rawResponse"
+        class="bg-gray-50 border border-gray-200 rounded-lg p-4 mb-6"
+      >
+        <h4 class="text-sm font-bold text-gray-900 mb-2">
+          Raw API Response
+        </h4>
+        <pre
+          class="text-xs bg-white p-3 rounded border border-gray-200 overflow-x-auto"
+          x-text="JSON.stringify(rawResponse, null, 2)"
+        ></pre>
+        <p class="text-xs text-gray-600 mt-2">
+          HTTP Status: <span class="mono" x-text="httpStatus"></span>
+        </p>
+      </div>
+
+      <!-- API Documentation -->
+      <div class="bg-gray-50 border border-gray-200 rounded-lg p-4">
+        <h4 class="text-sm font-bold text-gray-900 mb-2">Admin API</h4>
+        <div class="text-xs text-gray-700 space-y-2">
+          <div>
+            <p class="font-mono mb-1">DELETE /admin/auth/users/{user_id}</p>
+            <p class="ml-4">
+              Deletes a user and all associated sessions and tokens.
+            </p>
+            <pre
+              class="ml-4 mt-1 bg-white p-2 rounded border text-xs"
+            >Headers:
+  X-Admin-Token: {admin_token}
+
+Response 204 No Content (success)
+Response 401 Unauthorized (invalid admin token)
+Response 404 Not Found (user not found)</pre
+            >
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <script>
+      function adminPanel() {
+        return {
+          adminToken: null,
+          deleteUserId: null,
+          loading: false,
+          error: null,
+          success: null,
+          rawResponse: null,
+          httpStatus: null,
+          showConfirmation: false,
+          confirmChecks: {
+            dataDeleted: false,
+            sessionsRevoked: false,
+            cannotUndo: false,
+          },
+
+          async testAuth() {
+            this.loading = true;
+            this.error = null;
+            this.success = null;
+
+            try {
+              // Try to make an admin API call to test auth
+              // We'll try to get a non-existent user as a test
+              const apiBase = getAPIBase();
+              const res = await fetch(
+                `${apiBase}/admin/auth/users/00000000-0000-0000-0000-000000000000`,
+                {
+                  method: "DELETE",
+                  headers: {
+                    "X-Admin-Token": this.adminToken,
+                  },
+                }
+              );
+
+              // 401 = bad auth, 404 = good auth but user not found
+              if (res.status === 401 || res.status === 403) {
+                this.error = "Invalid admin token";
+              } else if (res.status === 404) {
+                this.success = "Admin token is valid";
+              } else {
+                this.success = "Admin authentication test completed";
+              }
+            } catch (err) {
+              this.error = "Network error: " + err.message;
+            } finally {
+              this.loading = false;
+            }
+          },
+
+          clearAuth() {
+            this.adminToken = null;
+            this.deleteUserId = null;
+            this.showConfirmation = false;
+            this.resetConfirmation();
+            this.success = "Admin token cleared";
+          },
+
+          async executeDeleteUser() {
+            this.loading = true;
+            this.error = null;
+            this.success = null;
+            this.rawResponse = null;
+
+            try {
+              const apiBase = getAPIBase();
+              const res = await fetch(
+                `${apiBase}/admin/auth/users/${this.deleteUserId}`,
+                {
+                  method: "DELETE",
+                  headers: {
+                    "X-Admin-Token": this.adminToken,
+                  },
+                }
+              );
+
+              this.httpStatus = res.status;
+
+              // Handle different status codes
+              if (res.status === 204) {
+                this.success = `User ${this.deleteUserId} deleted successfully. All sessions and tokens have been revoked.`;
+                this.rawResponse = { status: "204 No Content" };
+                this.deleteUserId = null;
+                this.cancelDelete();
+                return;
+              }
+
+              // Try to parse error response
+              try {
+                const data = await res.json();
+                this.rawResponse = data;
+
+                if (res.status === 401 || res.status === 403) {
+                  this.error = "Unauthorized: Invalid admin token";
+                } else if (res.status === 404) {
+                  this.error = "User not found";
+                } else if (res.status === 400) {
+                  this.error =
+                    data.error_description ||
+                    data.error ||
+                    data.message ||
+                    "Invalid user ID format";
+                } else {
+                  this.error =
+                    data.error_description ||
+                    data.error ||
+                    data.message ||
+                    "User deletion failed";
+                }
+              } catch {
+                // No JSON response
+                if (res.status === 401 || res.status === 403) {
+                  this.error = "Unauthorized: Invalid admin token";
+                } else {
+                  this.error = `HTTP ${res.status}: ${res.statusText}`;
+                }
+              }
+            } catch (err) {
+              this.error = "Network error: " + err.message;
+            } finally {
+              this.loading = false;
+            }
+          },
+
+          cancelDelete() {
+            this.showConfirmation = false;
+            this.resetConfirmation();
+          },
+
+          resetConfirmation() {
+            this.confirmChecks.dataDeleted = false;
+            this.confirmChecks.sessionsRevoked = false;
+            this.confirmChecks.cannotUndo = false;
+          },
+
+          allConfirmed() {
+            return (
+              this.confirmChecks.dataDeleted &&
+              this.confirmChecks.sessionsRevoked &&
+              this.confirmChecks.cannotUndo
+            );
+          },
+        };
+      }
+    </script>
+  </body>
+</html>

--- a/frontend/public/demo/authorize.html
+++ b/frontend/public/demo/authorize.html
@@ -1,0 +1,330 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OAuth2 Authorization - Credo Demo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script
+      defer
+      src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"
+    ></script>
+    <link rel="stylesheet" href="/css/styles.css" />
+  </head>
+  <body class="bg-gray-50 min-h-screen">
+    <div
+      style="
+        background: #fff3cd;
+        color: #664d03;
+        padding: 10px;
+        font-size: 14px;
+        border-bottom: 1px solid #ffeeba;
+        text-align: center;
+      "
+    >
+      Demo environment only. No real identity data is processed or stored.
+    </div>
+
+    <!-- Navigation -->
+    <nav class="bg-white shadow-sm border-b border-gray-200">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="flex justify-between items-center h-16">
+          <div class="flex items-center">
+            <h1 class="text-xl font-bold text-gray-900">
+              OAuth2 Demo - Authorization
+            </h1>
+          </div>
+          <div class="flex items-center space-x-4">
+            <a
+              href="/demo/index.html"
+              class="text-sm text-blue-600 hover:text-blue-800 font-medium"
+              >← Demo Home</a
+            >
+            <a
+              href="/index.html"
+              class="text-sm text-gray-600 hover:text-gray-900"
+              >User Portal</a
+            >
+          </div>
+        </div>
+      </div>
+    </nav>
+
+    <main
+      class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8"
+      x-data="authorizeFlow()"
+    >
+      <!-- Information Banner -->
+      <div class="bg-blue-50 border border-blue-200 rounded-lg p-6 mb-6">
+        <h2 class="text-lg font-bold text-blue-900 mb-2">
+          OAuth2 Authorization Request
+        </h2>
+        <p class="text-sm text-blue-800 mb-2">
+          This page initiates the OAuth2 authorization code flow. After you
+          submit, you will be redirected to the callback page with an
+          authorization code.
+        </p>
+        <p class="text-xs text-blue-700">
+          <strong>Important:</strong> This demonstrates a real OAuth redirect.
+          The authorization and token exchange happen on separate pages.
+        </p>
+      </div>
+
+      <!-- Authorization Form -->
+      <div class="bg-white rounded-lg shadow-md p-6 mb-6">
+        <h3 class="text-lg font-bold text-gray-900 mb-4">
+          Authorization Request
+        </h3>
+
+        <form @submit.prevent="authorize" class="space-y-4">
+          <!-- Email -->
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-2"
+              >Email Address</label
+            >
+            <input
+              type="email"
+              x-model="form.email"
+              required
+              placeholder="user@example.com"
+              class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <p class="text-xs text-gray-500 mt-1">
+              Demo users: alice@example.com, bob@example.com,
+              charlie@example.com
+            </p>
+          </div>
+
+          <!-- Client ID -->
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-2"
+              >Client ID</label
+            >
+            <input
+              type="text"
+              x-model="form.client_id"
+              required
+              class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <!-- Redirect URI -->
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-2"
+              >Redirect URI</label
+            >
+            <input
+              type="text"
+              x-model="form.redirect_uri"
+              required
+              class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <p class="text-xs text-gray-500 mt-1">
+              The callback page will receive the authorization code
+            </p>
+          </div>
+
+          <!-- State (optional) -->
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-2"
+              >State (optional CSRF protection)</label
+            >
+            <input
+              type="text"
+              x-model="form.state"
+              placeholder="random-state-value"
+              class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <p class="text-xs text-gray-500 mt-1">
+              State parameter for CSRF protection (will be echoed back)
+            </p>
+          </div>
+
+          <!-- Scopes -->
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-2"
+              >Requested Scopes</label
+            >
+            <div class="space-y-2">
+              <label class="flex items-center">
+                <input
+                  type="checkbox"
+                  value="openid"
+                  x-model="form.scopes"
+                  class="mr-2"
+                />
+                <span class="text-sm">openid - OIDC identity</span>
+              </label>
+              <label class="flex items-center">
+                <input
+                  type="checkbox"
+                  value="profile"
+                  x-model="form.scopes"
+                  class="mr-2"
+                />
+                <span class="text-sm">profile - User profile information</span>
+              </label>
+            </div>
+          </div>
+
+          <!-- Submit Button -->
+          <div class="pt-4">
+            <button
+              type="submit"
+              :disabled="loading"
+              class="w-full bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+            >
+              <span x-show="!loading">Authorize</span>
+              <span x-show="loading">
+                <span class="spinner"></span>
+                Authorizing...
+              </span>
+            </button>
+          </div>
+        </form>
+      </div>
+
+      <!-- Error Display -->
+      <div
+        x-show="error"
+        class="bg-red-50 border border-red-200 rounded-lg p-4 mb-6"
+      >
+        <h4 class="text-sm font-bold text-red-900 mb-2">Error</h4>
+        <p class="text-sm text-red-800" x-text="error"></p>
+      </div>
+
+      <!-- Response Display (only shown on error, redirect happens on success) -->
+      <div
+        x-show="response"
+        class="bg-gray-50 border border-gray-200 rounded-lg p-4"
+      >
+        <h4 class="text-sm font-bold text-gray-900 mb-2">
+          Authorization Response
+        </h4>
+        <pre
+          class="text-xs bg-white p-3 rounded border border-gray-200 overflow-x-auto"
+          x-text="JSON.stringify(response, null, 2)"
+        ></pre>
+        <p class="text-xs text-gray-600 mt-2">
+          HTTP Status: <span class="mono" x-text="httpStatus"></span>
+        </p>
+      </div>
+
+      <!-- Debug Info -->
+      <div class="bg-gray-50 border border-gray-200 rounded-lg p-4 mt-6">
+        <h4 class="text-sm font-bold text-gray-900 mb-2">OAuth Flow Info</h4>
+        <ul class="text-xs text-gray-700 space-y-1">
+          <li>
+            <strong>Step 1:</strong> Fill out the form and click "Authorize"
+          </li>
+          <li>
+            <strong>Step 2:</strong> Backend issues authorization code and
+            returns redirect URI
+          </li>
+          <li>
+            <strong>Step 3:</strong> Browser redirects to callback page with
+            code and state
+          </li>
+          <li>
+            <strong>Step 4:</strong> Callback page exchanges code for tokens
+          </li>
+        </ul>
+      </div>
+    </main>
+
+    <script>
+      function authorizeFlow() {
+        return {
+          form: {
+            email: "alice@example.com",
+            client_id: "demo-client",
+            redirect_uri:
+              window.location.protocol +
+              "//" +
+              window.location.host +
+              "/demo/callback.html",
+            state: "demo-state-" + Math.random().toString(36).substring(7),
+            scopes: ["openid", "profile"],
+          },
+          loading: false,
+          error: null,
+          response: null,
+          httpStatus: null,
+
+          async authorize() {
+            this.loading = true;
+            this.error = null;
+            this.response = null;
+            this.httpStatus = null;
+
+            try {
+              // Determine API base URL
+              const apiBase = this.getAPIBase();
+
+              const res = await fetch(`${apiBase}/auth/authorize`, {
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                  email: this.form.email,
+                  client_id: this.form.client_id,
+                  redirect_uri: this.form.redirect_uri,
+                  state: this.form.state,
+                  scopes: this.form.scopes,
+                }),
+              });
+
+              this.httpStatus = res.status;
+              const data = await res.json();
+              this.response = data;
+
+              if (!res.ok) {
+                this.error =
+                  data.error_description ||
+                  data.error ||
+                  data.message ||
+                  "Authorization failed";
+                return;
+              }
+
+              // Success - perform real redirect
+              if (data.code && data.redirect_uri) {
+                const redirectUrl = new URL(data.redirect_uri);
+                redirectUrl.searchParams.append("code", data.code);
+                if (this.form.state) {
+                  redirectUrl.searchParams.append("state", this.form.state);
+                }
+
+                // Redirect the browser
+                window.location.href = redirectUrl.toString();
+              } else {
+                this.error = "Invalid response: missing code or redirect_uri";
+              }
+            } catch (err) {
+              this.error = err.message || "Network error";
+            } finally {
+              this.loading = false;
+            }
+          },
+
+          getAPIBase() {
+            // If running on port 3000 (docker frontend), use /api proxy
+            if (window.location.port === "3000") {
+              return "/api";
+            }
+            // If running locally on different port, directly call backend
+            if (
+              window.location.hostname === "localhost" ||
+              window.location.hostname === "127.0.0.1"
+            ) {
+              return "http://localhost:8080";
+            }
+            // Production - use same origin
+            return "";
+          },
+        };
+      }
+    </script>
+  </body>
+</html>

--- a/frontend/public/demo/callback.html
+++ b/frontend/public/demo/callback.html
@@ -1,0 +1,394 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OAuth2 Callback - Credo Demo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script
+      defer
+      src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"
+    ></script>
+    <link rel="stylesheet" href="/css/styles.css" />
+  </head>
+  <body class="bg-gray-50 min-h-screen">
+    <div
+      style="
+        background: #fff3cd;
+        color: #664d03;
+        padding: 10px;
+        font-size: 14px;
+        border-bottom: 1px solid #ffeeba;
+        text-align: center;
+      "
+    >
+      Demo environment only. No real identity data is processed or stored.
+    </div>
+
+    <!-- Navigation -->
+    <nav class="bg-white shadow-sm border-b border-gray-200">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="flex justify-between items-center h-16">
+          <div class="flex items-center">
+            <h1 class="text-xl font-bold text-gray-900">
+              OAuth2 Demo - Callback
+            </h1>
+          </div>
+          <div class="flex items-center space-x-4">
+            <a
+              href="/demo/index.html"
+              class="text-sm text-blue-600 hover:text-blue-800 font-medium"
+              >← Demo Home</a
+            >
+            <a
+              href="/demo/authorize.html"
+              class="text-sm text-gray-600 hover:text-gray-900"
+              >Start New Flow</a
+            >
+          </div>
+        </div>
+      </div>
+    </nav>
+
+    <main
+      class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8"
+      x-data="callbackFlow()"
+      x-init="init()"
+    >
+      <!-- Information Banner -->
+      <div class="bg-green-50 border border-green-200 rounded-lg p-6 mb-6">
+        <h2 class="text-lg font-bold text-green-900 mb-2">
+          OAuth2 Callback Page
+        </h2>
+        <p class="text-sm text-green-800 mb-2">
+          You have been redirected here with an authorization code. Click
+          "Exchange Code for Tokens" to complete the OAuth flow.
+        </p>
+        <p class="text-xs text-green-700">
+          <strong>Note:</strong> This page parses the code and state from URL
+          query parameters.
+        </p>
+      </div>
+
+      <!-- URL Parameters Display -->
+      <div class="bg-white rounded-lg shadow-md p-6 mb-6">
+        <h3 class="text-lg font-bold text-gray-900 mb-4">
+          Received Parameters
+        </h3>
+
+        <div class="space-y-3">
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1"
+              >Authorization Code</label
+            >
+            <div
+              class="px-3 py-2 bg-gray-50 border border-gray-300 rounded-md mono text-sm break-all"
+              x-text="params.code || '(not found)'"
+            ></div>
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1"
+              >State</label
+            >
+            <div
+              class="px-3 py-2 bg-gray-50 border border-gray-300 rounded-md mono text-sm break-all"
+              x-text="params.state || '(not found)'"
+            ></div>
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1"
+              >Client ID</label
+            >
+            <input
+              type="text"
+              x-model="tokenRequest.client_id"
+              class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1"
+              >Redirect URI (must match)</label
+            >
+            <input
+              type="text"
+              x-model="tokenRequest.redirect_uri"
+              class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+        </div>
+
+        <!-- Exchange Button -->
+        <div class="mt-6">
+          <button
+            @click="exchangeCode"
+            :disabled="!params.code || loading"
+            class="w-full bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+          >
+            <span x-show="!loading">Exchange Code for Tokens</span>
+            <span x-show="loading">
+              <span class="spinner"></span>
+              Exchanging...
+            </span>
+          </button>
+        </div>
+      </div>
+
+      <!-- Error Display -->
+      <div
+        x-show="error"
+        class="bg-red-50 border border-red-200 rounded-lg p-4 mb-6"
+      >
+        <h4 class="text-sm font-bold text-red-900 mb-2">Error</h4>
+        <p class="text-sm text-red-800" x-text="error"></p>
+      </div>
+
+      <!-- Token Response Display -->
+      <div
+        x-show="tokenResponse"
+        class="bg-white rounded-lg shadow-md p-6 mb-6"
+      >
+        <h3 class="text-lg font-bold text-gray-900 mb-4">Token Response</h3>
+
+        <div class="space-y-4">
+          <!-- Raw JSON Response -->
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-2"
+              >Raw JSON Response</label
+            >
+            <pre
+              class="text-xs bg-gray-50 p-3 rounded border border-gray-200 overflow-x-auto"
+              x-text="JSON.stringify(tokenResponse, null, 2)"
+            ></pre>
+            <p class="text-xs text-gray-600 mt-1">
+              HTTP Status: <span class="mono" x-text="httpStatus"></span>
+            </p>
+          </div>
+
+          <!-- Decoded Access Token -->
+          <div x-show="decodedAccessToken">
+            <label class="block text-sm font-medium text-gray-700 mb-2"
+              >Decoded Access Token (JWT Claims)</label
+            >
+            <pre
+              class="text-xs bg-blue-50 p-3 rounded border border-blue-200 overflow-x-auto"
+              x-text="JSON.stringify(decodedAccessToken, null, 2)"
+            ></pre>
+          </div>
+
+          <!-- Decoded ID Token -->
+          <div x-show="decodedIDToken">
+            <label class="block text-sm font-medium text-gray-700 mb-2"
+              >Decoded ID Token (JWT Claims)</label
+            >
+            <pre
+              class="text-xs bg-green-50 p-3 rounded border border-green-200 overflow-x-auto"
+              x-text="JSON.stringify(decodedIDToken, null, 2)"
+            ></pre>
+          </div>
+
+          <!-- Token Expiry Info -->
+          <div x-show="expiryInfo" class="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+            <h4 class="text-sm font-bold text-yellow-900 mb-2">Token Expiry</h4>
+            <p class="text-sm text-yellow-800">
+              Expires in: <span class="font-mono" x-text="expiryInfo"></span>
+            </p>
+          </div>
+
+          <!-- Next Steps -->
+          <div class="bg-blue-50 border border-blue-200 rounded-lg p-4">
+            <h4 class="text-sm font-bold text-blue-900 mb-2">Next Steps</h4>
+            <div class="space-y-2 text-sm text-blue-800">
+              <p>
+                ✓ You now have access and ID tokens. You can use these to:
+              </p>
+              <ul class="list-disc list-inside ml-4 space-y-1">
+                <li>
+                  <a
+                    href="/demo/tokens.html"
+                    class="text-blue-600 underline hover:text-blue-800"
+                    @click="storeTokens"
+                    >Manage tokens (refresh, revoke)</a
+                  >
+                </li>
+                <li>
+                  <a
+                    href="/demo/sessions.html"
+                    class="text-blue-600 underline hover:text-blue-800"
+                    @click="storeTokens"
+                    >View and manage sessions</a
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Debug Info -->
+      <div class="bg-gray-50 border border-gray-200 rounded-lg p-4 mt-6">
+        <h4 class="text-sm font-bold text-gray-900 mb-2">OAuth Flow Steps</h4>
+        <ul class="text-xs text-gray-700 space-y-1">
+          <li>✓ <strong>Step 1:</strong> Authorization request submitted</li>
+          <li>✓ <strong>Step 2:</strong> Authorization code received</li>
+          <li>✓ <strong>Step 3:</strong> Redirected to callback page</li>
+          <li
+            x-bind:class="tokenResponse ? 'text-green-700 font-bold' : ''"
+          >
+            <span x-show="!tokenResponse">⏳</span>
+            <span x-show="tokenResponse">✓</span>
+            <strong>Step 4:</strong> Exchange code for tokens
+          </li>
+        </ul>
+      </div>
+    </main>
+
+    <script>
+      function callbackFlow() {
+        return {
+          params: {
+            code: null,
+            state: null,
+          },
+          tokenRequest: {
+            grant_type: "authorization_code",
+            code: null,
+            redirect_uri: null,
+            client_id: "demo-client",
+          },
+          loading: false,
+          error: null,
+          tokenResponse: null,
+          httpStatus: null,
+          decodedAccessToken: null,
+          decodedIDToken: null,
+          expiryInfo: null,
+
+          init() {
+            // Parse query parameters
+            const urlParams = new URLSearchParams(window.location.search);
+            this.params.code = urlParams.get("code");
+            this.params.state = urlParams.get("state");
+
+            // Pre-fill token request
+            this.tokenRequest.code = this.params.code;
+            this.tokenRequest.redirect_uri =
+              window.location.protocol +
+              "//" +
+              window.location.host +
+              window.location.pathname;
+          },
+
+          async exchangeCode() {
+            this.loading = true;
+            this.error = null;
+            this.tokenResponse = null;
+            this.httpStatus = null;
+            this.decodedAccessToken = null;
+            this.decodedIDToken = null;
+            this.expiryInfo = null;
+
+            try {
+              const apiBase = this.getAPIBase();
+
+              const res = await fetch(`${apiBase}/auth/token`, {
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/json",
+                },
+                body: JSON.stringify(this.tokenRequest),
+              });
+
+              this.httpStatus = res.status;
+              const data = await res.json();
+
+              if (!res.ok) {
+                this.error =
+                  data.error_description ||
+                  data.error ||
+                  data.message ||
+                  "Token exchange failed";
+                this.tokenResponse = data;
+                return;
+              }
+
+              this.tokenResponse = data;
+
+              // Decode JWTs
+              if (data.access_token) {
+                this.decodedAccessToken = this.decodeJWT(data.access_token);
+              }
+              if (data.id_token) {
+                this.decodedIDToken = this.decodeJWT(data.id_token);
+              }
+
+              // Calculate expiry
+              if (data.expires_in) {
+                const seconds = parseInt(data.expires_in) / 1000000000; // Convert nanoseconds to seconds
+                const minutes = Math.floor(seconds / 60);
+                const remainingSeconds = Math.floor(seconds % 60);
+                this.expiryInfo = `${minutes}m ${remainingSeconds}s`;
+              }
+
+              // Store tokens in sessionStorage for other demo pages
+              sessionStorage.setItem("access_token", data.access_token);
+              if (data.id_token) {
+                sessionStorage.setItem("id_token", data.id_token);
+              }
+            } catch (err) {
+              this.error = err.message || "Network error";
+            } finally {
+              this.loading = false;
+            }
+          },
+
+          decodeJWT(token) {
+            try {
+              const parts = token.split(".");
+              if (parts.length !== 3) {
+                return { error: "Invalid JWT format" };
+              }
+              const payload = parts[1];
+              const decoded = JSON.parse(atob(payload));
+
+              // Convert timestamps to readable dates
+              if (decoded.exp) {
+                decoded._exp_readable = new Date(decoded.exp * 1000).toISOString();
+              }
+              if (decoded.iat) {
+                decoded._iat_readable = new Date(decoded.iat * 1000).toISOString();
+              }
+              if (decoded.nbf) {
+                decoded._nbf_readable = new Date(decoded.nbf * 1000).toISOString();
+              }
+
+              return decoded;
+            } catch (err) {
+              return { error: "Failed to decode JWT", details: err.message };
+            }
+          },
+
+          storeTokens() {
+            // Tokens are already stored in sessionStorage
+            // This just ensures they're available for next page
+          },
+
+          getAPIBase() {
+            if (window.location.port === "3000") {
+              return "/api";
+            }
+            if (
+              window.location.hostname === "localhost" ||
+              window.location.hostname === "127.0.0.1"
+            ) {
+              return "http://localhost:8080";
+            }
+            return "";
+          },
+        };
+      }
+    </script>
+  </body>
+</html>

--- a/frontend/public/demo/index.html
+++ b/frontend/public/demo/index.html
@@ -1,0 +1,410 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OAuth2 Demo Home - Credo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script
+      defer
+      src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"
+    ></script>
+    <link rel="stylesheet" href="/css/styles.css" />
+  </head>
+  <body class="bg-gray-50 min-h-screen">
+    <div
+      style="
+        background: #fff3cd;
+        color: #664d03;
+        padding: 10px;
+        font-size: 14px;
+        border-bottom: 1px solid #ffeeba;
+        text-align: center;
+      "
+    >
+      Demo environment only. No real identity data is processed or stored.
+    </div>
+
+    <!-- Navigation -->
+    <nav class="bg-white shadow-sm border-b border-gray-200">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="flex justify-between items-center h-16">
+          <div class="flex items-center">
+            <h1 class="text-xl font-bold text-gray-900">
+              Credo OAuth2 Demo Suite
+            </h1>
+          </div>
+          <div class="flex items-center space-x-4">
+            <a
+              href="/index.html"
+              class="text-sm text-gray-600 hover:text-gray-900"
+              >User Portal</a
+            >
+            <a
+              href="/demo.html"
+              class="text-sm text-gray-600 hover:text-gray-900"
+              >Legacy Demo</a
+            >
+          </div>
+        </div>
+      </div>
+    </nav>
+
+    <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <!-- Hero Section -->
+      <div class="bg-gradient-to-r from-blue-600 to-indigo-600 rounded-lg shadow-lg p-8 mb-8 text-white">
+        <h2 class="text-3xl font-bold mb-4">OAuth2 Authorization Code Flow Demo</h2>
+        <p class="text-lg mb-4">
+          A comprehensive demonstration of OAuth2 authorization code flow with
+          real redirects, token management, and session controls.
+        </p>
+        <p class="text-sm opacity-90">
+          This demo suite shows proper OAuth2 implementation with separate pages
+          for authorization, callback, and resource management. No SPA routing,
+          no localStorage - just pure OAuth2 semantics.
+        </p>
+      </div>
+
+      <!-- Quick Start Guide -->
+      <div class="bg-blue-50 border border-blue-200 rounded-lg p-6 mb-8">
+        <h3 class="text-lg font-bold text-blue-900 mb-3">
+          🚀 Quick Start: Complete OAuth Flow
+        </h3>
+        <ol class="text-sm text-blue-800 space-y-2 list-decimal list-inside">
+          <li>
+            Click <strong>"Start Authorization"</strong> below to begin the OAuth flow
+          </li>
+          <li>You'll be redirected to the callback page with an authorization code</li>
+          <li>Click "Exchange Code for Tokens" to get access and ID tokens</li>
+          <li>Use the tokens to explore session management and token lifecycle</li>
+        </ol>
+        <div class="mt-4">
+          <a
+            href="/demo/authorize.html"
+            class="inline-block bg-blue-600 text-white px-6 py-3 rounded-md hover:bg-blue-700 font-semibold"
+          >
+            ▶ Start Authorization Flow
+          </a>
+        </div>
+      </div>
+
+      <!-- Demo Pages -->
+      <div class="mb-8">
+        <h3 class="text-2xl font-bold text-gray-900 mb-4">Demo Pages</h3>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <!-- Authorize -->
+          <div class="bg-white rounded-lg shadow-md p-6 hover-card">
+            <div class="flex items-start mb-4">
+              <div class="bg-blue-100 rounded-lg p-3 mr-4">
+                <svg
+                  class="w-6 h-6 text-blue-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+                  />
+                </svg>
+              </div>
+              <div class="flex-1">
+                <h4 class="text-lg font-bold text-gray-900 mb-2">
+                  1. Authorization Request
+                </h4>
+                <p class="text-sm text-gray-600 mb-3">
+                  Initiate OAuth2 flow with user credentials and client
+                  information. Performs a real browser redirect.
+                </p>
+                <a
+                  href="/demo/authorize.html"
+                  class="text-blue-600 hover:text-blue-800 text-sm font-medium"
+                  >Open Authorize Page →</a
+                >
+              </div>
+            </div>
+            <div class="bg-gray-50 rounded p-3 text-xs">
+              <p class="font-mono text-gray-700">
+                POST /auth/authorize<br />
+                → redirect to callback with code
+              </p>
+            </div>
+          </div>
+
+          <!-- Callback -->
+          <div class="bg-white rounded-lg shadow-md p-6 hover-card">
+            <div class="flex items-start mb-4">
+              <div class="bg-green-100 rounded-lg p-3 mr-4">
+                <svg
+                  class="w-6 h-6 text-green-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"
+                  />
+                </svg>
+              </div>
+              <div class="flex-1">
+                <h4 class="text-lg font-bold text-gray-900 mb-2">
+                  2. OAuth Callback
+                </h4>
+                <p class="text-sm text-gray-600 mb-3">
+                  Receives authorization code and exchanges it for access and ID
+                  tokens. Decodes JWTs and shows metadata.
+                </p>
+                <a
+                  href="/demo/callback.html"
+                  class="text-green-600 hover:text-green-800 text-sm font-medium"
+                  >Open Callback Page →</a
+                >
+              </div>
+            </div>
+            <div class="bg-gray-50 rounded p-3 text-xs">
+              <p class="font-mono text-gray-700">
+                POST /auth/token<br />
+                grant_type=authorization_code
+              </p>
+            </div>
+          </div>
+
+          <!-- Sessions -->
+          <div class="bg-white rounded-lg shadow-md p-6 hover-card">
+            <div class="flex items-start mb-4">
+              <div class="bg-purple-100 rounded-lg p-3 mr-4">
+                <svg
+                  class="w-6 h-6 text-purple-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                  />
+                </svg>
+              </div>
+              <div class="flex-1">
+                <h4 class="text-lg font-bold text-gray-900 mb-2">
+                  3. Session Management
+                </h4>
+                <p class="text-sm text-gray-600 mb-3">
+                  View active sessions, revoke specific sessions, or logout all
+                  other devices. Requires valid access token.
+                </p>
+                <a
+                  href="/demo/sessions.html"
+                  class="text-purple-600 hover:text-purple-800 text-sm font-medium"
+                  >Open Sessions Page →</a
+                >
+              </div>
+            </div>
+            <div class="bg-gray-50 rounded p-3 text-xs">
+              <p class="font-mono text-gray-700">
+                GET /auth/sessions<br />
+                DELETE /auth/sessions/{id}
+              </p>
+            </div>
+          </div>
+
+          <!-- Tokens -->
+          <div class="bg-white rounded-lg shadow-md p-6 hover-card">
+            <div class="flex items-start mb-4">
+              <div class="bg-indigo-100 rounded-lg p-3 mr-4">
+                <svg
+                  class="w-6 h-6 text-indigo-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"
+                  />
+                </svg>
+              </div>
+              <div class="flex-1">
+                <h4 class="text-lg font-bold text-gray-900 mb-2">
+                  4. Token Lifecycle
+                </h4>
+                <p class="text-sm text-gray-600 mb-3">
+                  Analyze token metadata, refresh access tokens, and revoke
+                  tokens. Shows expiry countdown and JWT claims.
+                </p>
+                <a
+                  href="/demo/tokens.html"
+                  class="text-indigo-600 hover:text-indigo-800 text-sm font-medium"
+                  >Open Tokens Page →</a
+                >
+              </div>
+            </div>
+            <div class="bg-gray-50 rounded p-3 text-xs">
+              <p class="font-mono text-gray-700">
+                POST /auth/token (refresh)<br />
+                POST /auth/revoke
+              </p>
+            </div>
+          </div>
+
+          <!-- Admin -->
+          <div class="bg-white rounded-lg shadow-md p-6 hover-card border-2 border-red-200">
+            <div class="flex items-start mb-4">
+              <div class="bg-red-100 rounded-lg p-3 mr-4">
+                <svg
+                  class="w-6 h-6 text-red-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                  />
+                </svg>
+              </div>
+              <div class="flex-1">
+                <h4 class="text-lg font-bold text-red-900 mb-2">
+                  ⚠️ Admin Operations
+                </h4>
+                <p class="text-sm text-gray-600 mb-3">
+                  Destructive admin operations including user deletion. Requires
+                  admin token. Use with caution!
+                </p>
+                <a
+                  href="/demo/admin.html"
+                  class="text-red-600 hover:text-red-800 text-sm font-medium"
+                  >Open Admin Panel →</a
+                >
+              </div>
+            </div>
+            <div class="bg-red-50 rounded p-3 text-xs">
+              <p class="font-mono text-red-700">
+                DELETE /admin/auth/users/{id}<br />
+                X-Admin-Token required
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- OAuth Flow Diagram -->
+      <div class="bg-white rounded-lg shadow-md p-6 mb-8">
+        <h3 class="text-xl font-bold text-gray-900 mb-4">
+          OAuth2 Authorization Code Flow
+        </h3>
+        <div class="space-y-3">
+          <div class="flex items-start">
+            <div class="bg-blue-100 text-blue-800 rounded-full w-8 h-8 flex items-center justify-center font-bold text-sm mr-3 flex-shrink-0">
+              1
+            </div>
+            <div>
+              <p class="font-semibold text-gray-900">Authorization Request</p>
+              <p class="text-sm text-gray-600">
+                User provides credentials → Server issues authorization code →
+                Browser redirects to callback
+              </p>
+              <p class="text-xs font-mono text-gray-500 mt-1">
+                /demo/authorize.html
+              </p>
+            </div>
+          </div>
+          <div class="flex items-start">
+            <div class="bg-green-100 text-green-800 rounded-full w-8 h-8 flex items-center justify-center font-bold text-sm mr-3 flex-shrink-0">
+              2
+            </div>
+            <div>
+              <p class="font-semibold text-gray-900">Code Exchange</p>
+              <p class="text-sm text-gray-600">
+                Callback page receives code → User clicks to exchange → Server
+                issues tokens
+              </p>
+              <p class="text-xs font-mono text-gray-500 mt-1">
+                /demo/callback.html
+              </p>
+            </div>
+          </div>
+          <div class="flex items-start">
+            <div class="bg-purple-100 text-purple-800 rounded-full w-8 h-8 flex items-center justify-center font-bold text-sm mr-3 flex-shrink-0">
+              3
+            </div>
+            <div>
+              <p class="font-semibold text-gray-900">Resource Access</p>
+              <p class="text-sm text-gray-600">
+                Use access token to view sessions, manage tokens, or access
+                protected resources
+              </p>
+              <p class="text-xs font-mono text-gray-500 mt-1">
+                /demo/sessions.html, /demo/tokens.html
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Technical Details -->
+      <div class="bg-gray-50 border border-gray-200 rounded-lg p-6">
+        <h3 class="text-lg font-bold text-gray-900 mb-4">
+          Technical Implementation
+        </h3>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6 text-sm">
+          <div>
+            <h4 class="font-semibold text-gray-900 mb-2">Stack</h4>
+            <ul class="text-gray-700 space-y-1 list-disc list-inside">
+              <li>Plain HTML + CSS</li>
+              <li>Alpine.js for reactivity</li>
+              <li>Tailwind CSS for styling</li>
+              <li>No build tools, no SPA routing</li>
+            </ul>
+          </div>
+          <div>
+            <h4 class="font-semibold text-gray-900 mb-2">Key Features</h4>
+            <ul class="text-gray-700 space-y-1 list-disc list-inside">
+              <li>True browser redirects</li>
+              <li>Separate authorization & callback pages</li>
+              <li>No localStorage (sessionStorage only)</li>
+              <li>Raw JSON and HTTP status display</li>
+            </ul>
+          </div>
+          <div>
+            <h4 class="font-semibold text-gray-900 mb-2">OAuth Semantics</h4>
+            <ul class="text-gray-700 space-y-1 list-disc list-inside">
+              <li>State parameter for CSRF protection</li>
+              <li>Redirect URI validation</li>
+              <li>Code single-use enforcement</li>
+              <li>JWT token validation</li>
+            </ul>
+          </div>
+          <div>
+            <h4 class="font-semibold text-gray-900 mb-2">Demo Users</h4>
+            <ul class="text-gray-700 space-y-1 list-disc list-inside">
+              <li>alice@example.com</li>
+              <li>bob@example.com</li>
+              <li>charlie@example.com</li>
+              <li>Any email auto-creates user</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <footer class="bg-white border-t border-gray-200 mt-12">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+        <p class="text-center text-sm text-gray-600">
+          Credo OAuth2 Demo Suite - Built with Alpine.js and plain HTML
+        </p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/frontend/public/demo/sessions.html
+++ b/frontend/public/demo/sessions.html
@@ -1,0 +1,513 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Session Management - Credo Demo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="/js/oauth-helpers.js"></script>
+    <script
+      defer
+      src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"
+    ></script>
+    <link rel="stylesheet" href="/css/styles.css" />
+  </head>
+  <body class="bg-gray-50 min-h-screen">
+    <div
+      style="
+        background: #fff3cd;
+        color: #664d03;
+        padding: 10px;
+        font-size: 14px;
+        border-bottom: 1px solid #ffeeba;
+        text-align: center;
+      "
+    >
+      Demo environment only. No real identity data is processed or stored.
+    </div>
+
+    <!-- Navigation -->
+    <nav class="bg-white shadow-sm border-b border-gray-200">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="flex justify-between items-center h-16">
+          <div class="flex items-center">
+            <h1 class="text-xl font-bold text-gray-900">
+              OAuth2 Demo - Session Management
+            </h1>
+          </div>
+          <div class="flex items-center space-x-4">
+            <a
+              href="/demo/index.html"
+              class="text-sm text-blue-600 hover:text-blue-800 font-medium"
+              >← Demo Home</a
+            >
+            <a
+              href="/demo/authorize.html"
+              class="text-sm text-gray-600 hover:text-gray-900"
+              >New Authorization</a
+            >
+          </div>
+        </div>
+      </div>
+    </nav>
+
+    <main
+      class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8"
+      x-data="sessionManagement()"
+      x-init="init()"
+    >
+      <!-- Information Banner -->
+      <div class="bg-purple-50 border border-purple-200 rounded-lg p-6 mb-6">
+        <h2 class="text-lg font-bold text-purple-900 mb-2">
+          Session Management
+        </h2>
+        <p class="text-sm text-purple-800 mb-2">
+          View and manage your active sessions. You can revoke individual
+          sessions or log out of all other devices.
+        </p>
+        <p class="text-xs text-purple-700">
+          <strong>Requires:</strong> Valid access token from OAuth flow
+        </p>
+      </div>
+
+      <!-- Access Token Input -->
+      <div class="bg-white rounded-lg shadow-md p-6 mb-6">
+        <h3 class="text-lg font-bold text-gray-900 mb-4">Access Token</h3>
+        <div class="space-y-3">
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-2"
+              >Paste Access Token (or complete OAuth flow first)</label
+            >
+            <textarea
+              x-model="accessToken"
+              rows="3"
+              placeholder="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+              class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono text-xs"
+            ></textarea>
+          </div>
+          <div class="flex gap-2">
+            <button
+              @click="loadSessions"
+              :disabled="!accessToken || loading"
+              class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+            >
+              <span x-show="!loading">Load Sessions</span>
+              <span x-show="loading">
+                <span class="spinner"></span>
+                Loading...
+              </span>
+            </button>
+            <button
+              @click="clearToken"
+              class="bg-gray-200 text-gray-700 px-4 py-2 rounded-md hover:bg-gray-300"
+            >
+              Clear Token
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Error Display -->
+      <div
+        x-show="error"
+        class="bg-red-50 border border-red-200 rounded-lg p-4 mb-6"
+      >
+        <div class="flex items-start">
+          <div class="flex-1">
+            <h4 class="text-sm font-bold text-red-900 mb-1">Error</h4>
+            <p class="text-sm text-red-800" x-text="error"></p>
+          </div>
+          <button @click="error = null" class="text-red-600 hover:text-red-800">
+            ✕
+          </button>
+        </div>
+      </div>
+
+      <!-- Success Message -->
+      <div
+        x-show="success"
+        class="bg-green-50 border border-green-200 rounded-lg p-4 mb-6"
+      >
+        <div class="flex items-start">
+          <div class="flex-1">
+            <h4 class="text-sm font-bold text-green-900 mb-1">Success</h4>
+            <p class="text-sm text-green-800" x-text="success"></p>
+          </div>
+          <button
+            @click="success = null"
+            class="text-green-600 hover:text-green-800"
+          >
+            ✕
+          </button>
+        </div>
+      </div>
+
+      <!-- Backend Not Available Notice -->
+      <div
+        x-show="backendNotAvailable"
+        class="bg-yellow-50 border border-yellow-200 rounded-lg p-6 mb-6"
+      >
+        <h3 class="text-lg font-bold text-yellow-900 mb-2">
+          ⚠️ Session Management Endpoints Not Yet Implemented
+        </h3>
+        <p class="text-sm text-yellow-800 mb-3">
+          The session management endpoints (GET /auth/sessions, DELETE
+          /auth/sessions/{id}) are not yet available in the backend.
+        </p>
+        <p class="text-sm text-yellow-800 mb-3">
+          <strong>Expected API Contract:</strong>
+        </p>
+        <div class="bg-white border border-yellow-300 rounded p-3 mb-3">
+          <p class="text-xs font-mono text-gray-700 mb-2">
+            GET /auth/sessions
+          </p>
+          <pre
+            class="text-xs bg-gray-50 p-2 rounded overflow-x-auto"
+          >Headers: Authorization: Bearer {access_token}
+
+Response 200 OK:
+{
+  "sessions": [
+    {
+      "id": "uuid",
+      "device": "Chrome on macOS",
+      "location": "San Francisco, CA",
+      "created_at": "2025-12-13T10:00:00Z",
+      "last_seen": "2025-12-13T11:30:00Z",
+      "is_current": true
+    }
+  ]
+}</pre
+          >
+        </div>
+        <div class="bg-white border border-yellow-300 rounded p-3 mb-3">
+          <p class="text-xs font-mono text-gray-700 mb-2">
+            DELETE /auth/sessions/{session_id}
+          </p>
+          <pre
+            class="text-xs bg-gray-50 p-2 rounded overflow-x-auto"
+          >Headers: Authorization: Bearer {access_token}
+
+Response 204 No Content</pre
+          >
+        </div>
+        <div class="bg-white border border-yellow-300 rounded p-3">
+          <p class="text-xs font-mono text-gray-700 mb-2">
+            POST /auth/logout-all
+          </p>
+          <pre
+            class="text-xs bg-gray-50 p-2 rounded overflow-x-auto"
+          >Headers: Authorization: Bearer {access_token}
+Body: { "except_current": true }
+
+Response 200 OK:
+{ "revoked_count": 3 }</pre
+          >
+        </div>
+      </div>
+
+      <!-- Sessions List -->
+      <div x-show="sessions.length > 0" class="bg-white rounded-lg shadow-md p-6 mb-6">
+        <div class="flex justify-between items-center mb-4">
+          <h3 class="text-lg font-bold text-gray-900">Active Sessions</h3>
+          <button
+            @click="logoutAllOthers"
+            :disabled="loading"
+            class="bg-red-600 text-white px-3 py-1 text-sm rounded-md hover:bg-red-700 disabled:bg-gray-400"
+          >
+            Logout All Other Sessions
+          </button>
+        </div>
+
+        <div class="overflow-x-auto">
+          <table class="audit-table">
+            <thead>
+              <tr>
+                <th>Device</th>
+                <th>Location</th>
+                <th>Created</th>
+                <th>Last Seen</th>
+                <th>Status</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <template x-for="session in sessions" :key="session.id">
+                <tr>
+                  <td>
+                    <span class="text-sm" x-text="session.device"></span>
+                  </td>
+                  <td>
+                    <span class="text-sm" x-text="session.location"></span>
+                  </td>
+                  <td>
+                    <span class="text-xs text-gray-600" x-text="formatDate(session.created_at)"></span>
+                  </td>
+                  <td>
+                    <span class="text-xs text-gray-600" x-text="formatDate(session.last_seen)"></span>
+                  </td>
+                  <td>
+                    <span
+                      class="status-badge"
+                      :class="session.is_current ? 'pass' : 'pending'"
+                    >
+                      <span x-text="session.is_current ? 'Current' : 'Active'"></span>
+                    </span>
+                  </td>
+                  <td>
+                    <button
+                      x-show="!session.is_current"
+                      @click="revokeSession(session.id)"
+                      :disabled="loading"
+                      class="text-red-600 hover:text-red-800 text-sm disabled:text-gray-400"
+                    >
+                      Revoke
+                    </button>
+                    <span
+                      x-show="session.is_current"
+                      class="text-gray-400 text-sm"
+                    >
+                      (current)
+                    </span>
+                  </td>
+                </tr>
+              </template>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Raw API Response -->
+      <div
+        x-show="rawResponse"
+        class="bg-gray-50 border border-gray-200 rounded-lg p-4"
+      >
+        <h4 class="text-sm font-bold text-gray-900 mb-2">
+          Raw API Response
+        </h4>
+        <pre
+          class="text-xs bg-white p-3 rounded border border-gray-200 overflow-x-auto"
+          x-text="JSON.stringify(rawResponse, null, 2)"
+        ></pre>
+        <p class="text-xs text-gray-600 mt-2">
+          HTTP Status: <span class="mono" x-text="httpStatus"></span>
+        </p>
+      </div>
+
+      <!-- API Documentation -->
+      <div class="bg-gray-50 border border-gray-200 rounded-lg p-4 mt-6">
+        <h4 class="text-sm font-bold text-gray-900 mb-2">
+          Session Management API
+        </h4>
+        <ul class="text-xs text-gray-700 space-y-2">
+          <li>
+            <strong>GET /auth/sessions</strong> - List all active sessions for
+            the authenticated user
+          </li>
+          <li>
+            <strong>DELETE /auth/sessions/{id}</strong> - Revoke a specific
+            session
+          </li>
+          <li>
+            <strong>POST /auth/logout-all</strong> - Logout all sessions except
+            current (with except_current=true)
+          </li>
+        </ul>
+      </div>
+    </main>
+
+    <script>
+      function sessionManagement() {
+        return {
+          accessToken: null,
+          loading: false,
+          error: null,
+          success: null,
+          sessions: [],
+          rawResponse: null,
+          httpStatus: null,
+          backendNotAvailable: false,
+
+          init() {
+            // Try to load token from sessionStorage
+            const stored = getStoredTokens();
+            if (stored.accessToken) {
+              this.accessToken = stored.accessToken;
+            }
+          },
+
+          async loadSessions() {
+            this.loading = true;
+            this.error = null;
+            this.success = null;
+            this.rawResponse = null;
+            this.backendNotAvailable = false;
+
+            try {
+              const apiBase = getAPIBase();
+              const res = await fetch(`${apiBase}/auth/sessions`, {
+                method: "GET",
+                headers: {
+                  Authorization: `Bearer ${this.accessToken}`,
+                  "Content-Type": "application/json",
+                },
+              });
+
+              this.httpStatus = res.status;
+
+              // Handle 404 - endpoint not implemented
+              if (res.status === 404) {
+                this.backendNotAvailable = true;
+                this.error = "Session management endpoints not yet implemented in backend";
+                return;
+              }
+
+              const data = await res.json();
+              this.rawResponse = data;
+
+              if (!res.ok) {
+                this.error =
+                  data.error_description ||
+                  data.error ||
+                  data.message ||
+                  "Failed to load sessions";
+                return;
+              }
+
+              if (data.sessions && Array.isArray(data.sessions)) {
+                this.sessions = data.sessions;
+                this.success = `Loaded ${data.sessions.length} session(s)`;
+              } else {
+                this.error = "Unexpected response format";
+              }
+            } catch (err) {
+              this.error = err.message || "Network error";
+              this.backendNotAvailable = true;
+            } finally {
+              this.loading = false;
+            }
+          },
+
+          async revokeSession(sessionId) {
+            if (!confirm("Are you sure you want to revoke this session?")) {
+              return;
+            }
+
+            this.loading = true;
+            this.error = null;
+            this.success = null;
+
+            try {
+              const apiBase = getAPIBase();
+              const res = await fetch(`${apiBase}/auth/sessions/${sessionId}`, {
+                method: "DELETE",
+                headers: {
+                  Authorization: `Bearer ${this.accessToken}`,
+                  "Content-Type": "application/json",
+                },
+              });
+
+              this.httpStatus = res.status;
+
+              if (res.status === 404) {
+                this.backendNotAvailable = true;
+                this.error = "Session revocation endpoint not yet implemented";
+                return;
+              }
+
+              if (!res.ok) {
+                const data = await res.json();
+                this.error =
+                  data.error_description ||
+                  data.error ||
+                  data.message ||
+                  "Failed to revoke session";
+                return;
+              }
+
+              this.success = "Session revoked successfully";
+              // Reload sessions
+              await this.loadSessions();
+            } catch (err) {
+              this.error = err.message || "Network error";
+            } finally {
+              this.loading = false;
+            }
+          },
+
+          async logoutAllOthers() {
+            if (
+              !confirm(
+                "Are you sure you want to logout all other sessions? This will revoke all sessions except your current one."
+              )
+            ) {
+              return;
+            }
+
+            this.loading = true;
+            this.error = null;
+            this.success = null;
+
+            try {
+              const apiBase = getAPIBase();
+              const res = await fetch(`${apiBase}/auth/logout-all`, {
+                method: "POST",
+                headers: {
+                  Authorization: `Bearer ${this.accessToken}`,
+                  "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ except_current: true }),
+              });
+
+              this.httpStatus = res.status;
+
+              if (res.status === 404) {
+                this.backendNotAvailable = true;
+                this.error = "Logout-all endpoint not yet implemented";
+                return;
+              }
+
+              const data = await res.json();
+              this.rawResponse = data;
+
+              if (!res.ok) {
+                this.error =
+                  data.error_description ||
+                  data.error ||
+                  data.message ||
+                  "Failed to logout other sessions";
+                return;
+              }
+
+              this.success = `Successfully logged out ${data.revoked_count || 0} other session(s)`;
+              // Reload sessions
+              await this.loadSessions();
+            } catch (err) {
+              this.error = err.message || "Network error";
+            } finally {
+              this.loading = false;
+            }
+          },
+
+          clearToken() {
+            this.accessToken = null;
+            this.sessions = [];
+            this.rawResponse = null;
+            clearTokens();
+            this.success = "Token cleared";
+          },
+
+          formatDate(dateString) {
+            if (!dateString) return "N/A";
+            try {
+              const date = new Date(dateString);
+              return date.toLocaleString();
+            } catch {
+              return dateString;
+            }
+          },
+        };
+      }
+    </script>
+  </body>
+</html>

--- a/frontend/public/demo/tokens.html
+++ b/frontend/public/demo/tokens.html
@@ -1,0 +1,505 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Token Lifecycle - Credo Demo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="/js/oauth-helpers.js"></script>
+    <script
+      defer
+      src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"
+    ></script>
+    <link rel="stylesheet" href="/css/styles.css" />
+  </head>
+  <body class="bg-gray-50 min-h-screen">
+    <div
+      style="
+        background: #fff3cd;
+        color: #664d03;
+        padding: 10px;
+        font-size: 14px;
+        border-bottom: 1px solid #ffeeba;
+        text-align: center;
+      "
+    >
+      Demo environment only. No real identity data is processed or stored.
+    </div>
+
+    <!-- Navigation -->
+    <nav class="bg-white shadow-sm border-b border-gray-200">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="flex justify-between items-center h-16">
+          <div class="flex items-center">
+            <h1 class="text-xl font-bold text-gray-900">
+              OAuth2 Demo - Token Lifecycle
+            </h1>
+          </div>
+          <div class="flex items-center space-x-4">
+            <a
+              href="/demo/index.html"
+              class="text-sm text-blue-600 hover:text-blue-800 font-medium"
+              >← Demo Home</a
+            >
+            <a
+              href="/demo/authorize.html"
+              class="text-sm text-gray-600 hover:text-gray-900"
+              >New Authorization</a
+            >
+          </div>
+        </div>
+      </div>
+    </nav>
+
+    <main
+      class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8"
+      x-data="tokenLifecycle()"
+      x-init="init()"
+    >
+      <!-- Information Banner -->
+      <div class="bg-indigo-50 border border-indigo-200 rounded-lg p-6 mb-6">
+        <h2 class="text-lg font-bold text-indigo-900 mb-2">
+          Token Lifecycle Management
+        </h2>
+        <p class="text-sm text-indigo-800 mb-2">
+          View token metadata, refresh access tokens, and revoke tokens. This
+          page demonstrates the complete token lifecycle.
+        </p>
+        <p class="text-xs text-indigo-700">
+          <strong>Note:</strong> Refresh and revocation endpoints may not be
+          fully implemented yet.
+        </p>
+      </div>
+
+      <!-- Token Input -->
+      <div class="bg-white rounded-lg shadow-md p-6 mb-6">
+        <h3 class="text-lg font-bold text-gray-900 mb-4">Current Tokens</h3>
+        <div class="space-y-4">
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-2"
+              >Access Token</label
+            >
+            <textarea
+              x-model="tokens.access"
+              rows="3"
+              placeholder="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+              class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono text-xs"
+            ></textarea>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-2"
+              >Refresh Token (if available)</label
+            >
+            <textarea
+              x-model="tokens.refresh"
+              rows="2"
+              placeholder="Refresh token not yet supported"
+              class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono text-xs"
+              disabled
+            ></textarea>
+            <p class="text-xs text-gray-500 mt-1">
+              Refresh tokens are not currently issued by the backend
+            </p>
+          </div>
+          <div class="flex gap-2">
+            <button
+              @click="analyzeToken"
+              :disabled="!tokens.access"
+              class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+            >
+              Analyze Token
+            </button>
+            <button
+              @click="clearAllTokens"
+              class="bg-gray-200 text-gray-700 px-4 py-2 rounded-md hover:bg-gray-300"
+            >
+              Clear All
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Error Display -->
+      <div
+        x-show="error"
+        class="bg-red-50 border border-red-200 rounded-lg p-4 mb-6"
+      >
+        <div class="flex items-start">
+          <div class="flex-1">
+            <h4 class="text-sm font-bold text-red-900 mb-1">Error</h4>
+            <p class="text-sm text-red-800" x-text="error"></p>
+          </div>
+          <button @click="error = null" class="text-red-600 hover:text-red-800">
+            ✕
+          </button>
+        </div>
+      </div>
+
+      <!-- Success Message -->
+      <div
+        x-show="success"
+        class="bg-green-50 border border-green-200 rounded-lg p-4 mb-6"
+      >
+        <div class="flex items-start">
+          <div class="flex-1">
+            <h4 class="text-sm font-bold text-green-900 mb-1">Success</h4>
+            <p class="text-sm text-green-800" x-text="success"></p>
+          </div>
+          <button
+            @click="success = null"
+            class="text-green-600 hover:text-green-800"
+          >
+            ✕
+          </button>
+        </div>
+      </div>
+
+      <!-- Token Metadata -->
+      <div
+        x-show="metadata"
+        class="bg-white rounded-lg shadow-md p-6 mb-6"
+      >
+        <h3 class="text-lg font-bold text-gray-900 mb-4">Token Metadata</h3>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+          <div class="bg-blue-50 border border-blue-200 rounded p-3">
+            <p class="text-xs text-blue-700 font-semibold mb-1">Subject (sub)</p>
+            <p class="text-sm font-mono" x-text="metadata?.sub || 'N/A'"></p>
+          </div>
+          <div class="bg-blue-50 border border-blue-200 rounded p-3">
+            <p class="text-xs text-blue-700 font-semibold mb-1">Issuer (iss)</p>
+            <p class="text-sm font-mono" x-text="metadata?.iss || 'N/A'"></p>
+          </div>
+          <div class="bg-green-50 border border-green-200 rounded p-3">
+            <p class="text-xs text-green-700 font-semibold mb-1">Issued At</p>
+            <p class="text-sm" x-text="metadata?._iat_readable || 'N/A'"></p>
+          </div>
+          <div class="bg-yellow-50 border border-yellow-200 rounded p-3">
+            <p class="text-xs text-yellow-700 font-semibold mb-1">Expires At</p>
+            <p class="text-sm" x-text="metadata?._exp_readable || 'N/A'"></p>
+          </div>
+        </div>
+
+        <!-- Expiry Countdown -->
+        <div
+          x-show="expiryCountdown"
+          class="bg-yellow-50 border border-yellow-200 rounded-lg p-4 mb-4"
+        >
+          <h4 class="text-sm font-bold text-yellow-900 mb-2">
+            ⏱️ Token Expiry Countdown
+          </h4>
+          <p class="text-lg font-mono text-yellow-800" x-text="expiryCountdown"></p>
+        </div>
+
+        <!-- Full Claims -->
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-2"
+            >Full JWT Claims</label
+          >
+          <pre
+            class="text-xs bg-gray-50 p-3 rounded border border-gray-200 overflow-x-auto"
+            x-text="JSON.stringify(metadata, null, 2)"
+          ></pre>
+        </div>
+      </div>
+
+      <!-- Token Actions -->
+      <div class="bg-white rounded-lg shadow-md p-6 mb-6">
+        <h3 class="text-lg font-bold text-gray-900 mb-4">Token Actions</h3>
+
+        <div class="space-y-3">
+          <!-- Refresh Token -->
+          <div class="bg-gray-50 border border-gray-200 rounded p-4">
+            <div class="flex justify-between items-start mb-2">
+              <div>
+                <h4 class="text-sm font-bold text-gray-900">
+                  Refresh Access Token
+                </h4>
+                <p class="text-xs text-gray-600">
+                  Exchange refresh token for a new access token (extends session)
+                </p>
+              </div>
+            </div>
+            <button
+              @click="refreshToken"
+              :disabled="loading || !tokens.refresh"
+              class="bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed text-sm"
+            >
+              <span x-show="!loading">Refresh Token</span>
+              <span x-show="loading">
+                <span class="spinner"></span>
+                Refreshing...
+              </span>
+            </button>
+            <p class="text-xs text-yellow-700 mt-2">
+              ⚠️ Refresh token grant not yet implemented in backend
+            </p>
+          </div>
+
+          <!-- Revoke Token -->
+          <div class="bg-red-50 border border-red-200 rounded p-4">
+            <div class="flex justify-between items-start mb-2">
+              <div>
+                <h4 class="text-sm font-bold text-red-900">Revoke Token</h4>
+                <p class="text-xs text-red-700">
+                  Invalidate the current access token (logout)
+                </p>
+              </div>
+            </div>
+            <button
+              @click="revokeToken"
+              :disabled="loading || !tokens.access"
+              class="bg-red-600 text-white px-4 py-2 rounded-md hover:bg-red-700 disabled:bg-gray-400 disabled:cursor-not-allowed text-sm"
+            >
+              <span x-show="!loading">Revoke Token</span>
+              <span x-show="loading">
+                <span class="spinner"></span>
+                Revoking...
+              </span>
+            </button>
+            <p class="text-xs text-yellow-700 mt-2">
+              ⚠️ Token revocation endpoint not yet implemented in backend
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Raw API Response -->
+      <div
+        x-show="rawResponse"
+        class="bg-gray-50 border border-gray-200 rounded-lg p-4 mb-6"
+      >
+        <h4 class="text-sm font-bold text-gray-900 mb-2">
+          Raw API Response
+        </h4>
+        <pre
+          class="text-xs bg-white p-3 rounded border border-gray-200 overflow-x-auto"
+          x-text="JSON.stringify(rawResponse, null, 2)"
+        ></pre>
+        <p class="text-xs text-gray-600 mt-2">
+          HTTP Status: <span class="mono" x-text="httpStatus"></span>
+        </p>
+      </div>
+
+      <!-- API Documentation -->
+      <div class="bg-gray-50 border border-gray-200 rounded-lg p-4">
+        <h4 class="text-sm font-bold text-gray-900 mb-2">
+          Token Lifecycle API
+        </h4>
+        <ul class="text-xs text-gray-700 space-y-2">
+          <li>
+            <strong>POST /auth/token</strong> (grant_type=refresh_token) -
+            Refresh access token using refresh token
+          </li>
+          <li>
+            <strong>POST /auth/revoke</strong> - Revoke a token (access or
+            refresh)
+          </li>
+          <li>
+            <strong>Note:</strong> Current implementation only supports
+            authorization_code grant type
+          </li>
+        </ul>
+      </div>
+    </main>
+
+    <script>
+      function tokenLifecycle() {
+        return {
+          tokens: {
+            access: null,
+            refresh: null,
+          },
+          loading: false,
+          error: null,
+          success: null,
+          metadata: null,
+          expiryCountdown: null,
+          rawResponse: null,
+          httpStatus: null,
+          countdownInterval: null,
+
+          init() {
+            // Load tokens from sessionStorage
+            const stored = getStoredTokens();
+            if (stored.accessToken) {
+              this.tokens.access = stored.accessToken;
+              this.analyzeToken();
+            }
+
+            // Start expiry countdown
+            this.startExpiryCountdown();
+          },
+
+          analyzeToken() {
+            this.error = null;
+            this.metadata = null;
+
+            if (!this.tokens.access) {
+              this.error = "No access token to analyze";
+              return;
+            }
+
+            try {
+              this.metadata = decodeJWT(this.tokens.access);
+              if (this.metadata.error) {
+                this.error = this.metadata.error;
+                this.metadata = null;
+              } else {
+                this.success = "Token analyzed successfully";
+              }
+            } catch (err) {
+              this.error = "Failed to decode token: " + err.message;
+            }
+          },
+
+          startExpiryCountdown() {
+            if (this.countdownInterval) {
+              clearInterval(this.countdownInterval);
+            }
+
+            this.countdownInterval = setInterval(() => {
+              if (this.metadata && this.metadata.exp) {
+                const now = Math.floor(Date.now() / 1000);
+                const remaining = this.metadata.exp - now;
+
+                if (remaining <= 0) {
+                  this.expiryCountdown = "⚠️ Token expired";
+                  clearInterval(this.countdownInterval);
+                } else {
+                  const minutes = Math.floor(remaining / 60);
+                  const seconds = remaining % 60;
+                  this.expiryCountdown = `${minutes}m ${seconds}s remaining`;
+                }
+              } else {
+                this.expiryCountdown = null;
+              }
+            }, 1000);
+          },
+
+          async refreshToken() {
+            this.loading = true;
+            this.error = null;
+            this.success = null;
+            this.rawResponse = null;
+
+            try {
+              const apiBase = getAPIBase();
+              const res = await fetch(`${apiBase}/auth/token`, {
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                  grant_type: "refresh_token",
+                  refresh_token: this.tokens.refresh,
+                }),
+              });
+
+              this.httpStatus = res.status;
+              const data = await res.json();
+              this.rawResponse = data;
+
+              if (!res.ok) {
+                this.error =
+                  data.error_description ||
+                  data.error ||
+                  data.message ||
+                  "Token refresh failed";
+                return;
+              }
+
+              // Update tokens
+              if (data.access_token) {
+                this.tokens.access = data.access_token;
+                storeTokens(data.access_token, data.refresh_token);
+                this.analyzeToken();
+                this.success = "Token refreshed successfully";
+              }
+            } catch (err) {
+              this.error = err.message || "Network error";
+            } finally {
+              this.loading = false;
+            }
+          },
+
+          async revokeToken() {
+            if (
+              !confirm(
+                "Are you sure you want to revoke this token? This will log you out."
+              )
+            ) {
+              return;
+            }
+
+            this.loading = true;
+            this.error = null;
+            this.success = null;
+            this.rawResponse = null;
+
+            try {
+              const apiBase = getAPIBase();
+              const res = await fetch(`${apiBase}/auth/revoke`, {
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/json",
+                  Authorization: `Bearer ${this.tokens.access}`,
+                },
+                body: JSON.stringify({
+                  token: this.tokens.access,
+                  token_type_hint: "access_token",
+                }),
+              });
+
+              this.httpStatus = res.status;
+
+              // 404 means endpoint doesn't exist yet
+              if (res.status === 404) {
+                this.error = "Token revocation endpoint not yet implemented";
+                this.rawResponse = { error: "404 Not Found" };
+                return;
+              }
+
+              if (res.status === 204) {
+                this.success = "Token revoked successfully";
+                this.clearAllTokens();
+                return;
+              }
+
+              const data = await res.json();
+              this.rawResponse = data;
+
+              if (!res.ok) {
+                this.error =
+                  data.error_description ||
+                  data.error ||
+                  data.message ||
+                  "Token revocation failed";
+                return;
+              }
+
+              this.success = "Token revoked successfully";
+              this.clearAllTokens();
+            } catch (err) {
+              this.error = err.message || "Network error";
+            } finally {
+              this.loading = false;
+            }
+          },
+
+          clearAllTokens() {
+            this.tokens.access = null;
+            this.tokens.refresh = null;
+            this.metadata = null;
+            this.expiryCountdown = null;
+            clearTokens();
+            if (this.countdownInterval) {
+              clearInterval(this.countdownInterval);
+            }
+            this.success = "All tokens cleared";
+          },
+        };
+      }
+    </script>
+  </body>
+</html>

--- a/frontend/public/js/oauth-helpers.js
+++ b/frontend/public/js/oauth-helpers.js
@@ -1,0 +1,178 @@
+// Shared OAuth2 Helper Functions
+// Used across all demo pages to keep code DRY
+
+/**
+ * Determine API base URL based on environment
+ */
+function getAPIBase() {
+  // If running on port 3000 (docker frontend), use /api proxy
+  if (window.location.port === "3000") {
+    return "/api";
+  }
+  // If running locally on different port, directly call backend
+  if (
+    window.location.hostname === "localhost" ||
+    window.location.hostname === "127.0.0.1"
+  ) {
+    return "http://localhost:8080";
+  }
+  // Production - use same origin
+  return "";
+}
+
+/**
+ * Decode a JWT token and return the payload
+ * @param {string} token - JWT token
+ * @returns {object} Decoded payload with readable timestamps
+ */
+function decodeJWT(token) {
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 3) {
+      return { error: "Invalid JWT format" };
+    }
+    const payload = parts[1];
+    const decoded = JSON.parse(atob(payload));
+
+    // Convert timestamps to readable dates
+    if (decoded.exp) {
+      decoded._exp_readable = new Date(decoded.exp * 1000).toISOString();
+    }
+    if (decoded.iat) {
+      decoded._iat_readable = new Date(decoded.iat * 1000).toISOString();
+    }
+    if (decoded.nbf) {
+      decoded._nbf_readable = new Date(decoded.nbf * 1000).toISOString();
+    }
+
+    return decoded;
+  } catch (err) {
+    return { error: "Failed to decode JWT", details: err.message };
+  }
+}
+
+/**
+ * Make an API request with consistent error handling
+ * @param {string} endpoint - API endpoint (e.g., "/auth/authorize")
+ * @param {object} options - Fetch options
+ * @returns {Promise<{data: any, status: number, ok: boolean}>}
+ */
+async function apiRequest(endpoint, options = {}) {
+  const apiBase = getAPIBase();
+  const url = `${apiBase}${endpoint}`;
+
+  const headers = {
+    "Content-Type": "application/json",
+    ...options.headers,
+  };
+
+  // Add bearer token if available and not explicitly skipped
+  if (!options.skipAuth) {
+    const token =
+      sessionStorage.getItem("access_token") ||
+      localStorage.getItem("access_token");
+    if (token) {
+      headers["Authorization"] = `Bearer ${token}`;
+    }
+  }
+
+  const config = {
+    ...options,
+    headers,
+  };
+
+  const res = await fetch(url, config);
+  const status = res.status;
+  const ok = res.ok;
+
+  // Handle empty responses (204 No Content)
+  if (status === 204) {
+    return { data: null, status, ok };
+  }
+
+  const data = await res.json();
+
+  return { data, status, ok };
+}
+
+/**
+ * Format expiry time from nanoseconds to human-readable
+ * @param {number} expiresIn - Expiry time in nanoseconds
+ * @returns {string} Human-readable time (e.g., "15m 30s")
+ */
+function formatExpiry(expiresIn) {
+  const seconds = parseInt(expiresIn) / 1000000000; // Convert nanoseconds to seconds
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = Math.floor(seconds % 60);
+  return `${minutes}m ${remainingSeconds}s`;
+}
+
+/**
+ * Generate a random state value for CSRF protection
+ * @returns {string} Random state string
+ */
+function generateState() {
+  return "state-" + Math.random().toString(36).substring(7);
+}
+
+/**
+ * Get stored tokens from sessionStorage
+ * @returns {{accessToken: string|null, idToken: string|null}}
+ */
+function getStoredTokens() {
+  return {
+    accessToken: sessionStorage.getItem("access_token"),
+    idToken: sessionStorage.getItem("id_token"),
+  };
+}
+
+/**
+ * Store tokens in sessionStorage
+ * @param {string} accessToken
+ * @param {string} idToken
+ */
+function storeTokens(accessToken, idToken = null) {
+  if (accessToken) {
+    sessionStorage.setItem("access_token", accessToken);
+  }
+  if (idToken) {
+    sessionStorage.setItem("id_token", idToken);
+  }
+}
+
+/**
+ * Clear stored tokens
+ */
+function clearTokens() {
+  sessionStorage.removeItem("access_token");
+  sessionStorage.removeItem("id_token");
+}
+
+/**
+ * Build redirect URL with query parameters
+ * @param {string} baseUrl - Base redirect URL
+ * @param {string} code - Authorization code
+ * @param {string} state - State parameter
+ * @returns {string} Full redirect URL with params
+ */
+function buildRedirectUrl(baseUrl, code, state = null) {
+  const url = new URL(baseUrl);
+  url.searchParams.append("code", code);
+  if (state) {
+    url.searchParams.append("state", state);
+  }
+  return url.toString();
+}
+
+/**
+ * Parse query parameters from current URL
+ * @returns {object} Query parameters as key-value pairs
+ */
+function parseQueryParams() {
+  const params = {};
+  const urlParams = new URLSearchParams(window.location.search);
+  for (const [key, value] of urlParams) {
+    params[key] = value;
+  }
+  return params;
+}


### PR DESCRIPTION
Implements comprehensive OAuth2 authorization code flow demo with
separate pages and real redirects, replacing the single-page simulated
flow.

Key features:
- True browser redirects (not simulated)
- Separate /demo/authorize and /demo/callback pages
- Explicit token exchange requiring user action
- Session management UI (/demo/sessions.html)
- Token lifecycle management (/demo/tokens.html)
- Admin operations panel (/demo/admin.html)
- Shared oauth-helpers.js for DRY code
- No localStorage (sessionStorage only)
- All responses show raw JSON and HTTP status

Pages created:
- /demo/index.html - Landing page with overview
- /demo/authorize.html - OAuth authorization initiation
- /demo/callback.html - OAuth callback handler
- /demo/sessions.html - Session management (view/revoke)
- /demo/tokens.html - Token lifecycle (analyze/refresh/revoke)
- /demo/admin.html - Admin operations (user deletion)

Documentation:
- frontend/OAUTH_DEMO_README.md - Complete walkthrough guide
- README.md - Updated with demo suite section

Stack: Plain HTML + Alpine.js + Tailwind CSS (no build tools)
State: No shared state between pages, sessionStorage for tokens only
OAuth: Follows RFC 6749 semantics with state, redirect_uri validation