### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
 
   e2e:
     name: E2E Tests
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/abramin/Credo/security/code-scanning/2](https://github.com/abramin/Credo/security/code-scanning/2)

To fix the problem, the least privilege recommended is to explicitly set the `permissions` key for the `e2e` job in the workflow file. For this job, only `contents: read` is required (for checkout by `actions/checkout`). Adding  
```yaml
permissions:
  contents: read
```
right under the `e2e:` job definition (before or after the `name:` key, standard is immediately after `name:`) restricts the GITHUB_TOKEN to read-only access on repository contents for this job. No changes in imports, methods, or other files are necessary. Only one, clear YAML block needs to be added to `.github/workflows/ci.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
