### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,8 @@ jobs:
   combine-pages:
     name: Combine artifacts for Pages
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [openapi-docs, e2e-reports]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/abramin/Credo/security/code-scanning/5](https://github.com/abramin/Credo/security/code-scanning/5)

The best way to fix the problem is to add an explicit `permissions` block to the `combine-pages` job in `.github/workflows/ci.yml` to limit the job's `GITHUB_TOKEN` access as recommended. Since this job only interacts with the repository by checking out code and downloading/uploading artifacts, the minimal permissions needed are `contents: read`. This block should be added directly under the `runs-on` or `needs` fields of the `combine-pages` job (line 177 or 178), before `steps`. No additional imports or code changes are necessary since this is a workflow configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
