### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,8 @@ jobs:
 
   e2e-reports:
     name: Prepare E2E reports for Pages
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: e2e
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
Potential fix for [https://github.com/abramin/Credo/security/code-scanning/4](https://github.com/abramin/Credo/security/code-scanning/4)

To fix the problem, add a `permissions:` block at the top level of the `e2e-reports` job (immediately under the job’s name). Set this to the minimal permissions required; for artifact downloading and uploading, only `contents: read` is needed. This change should be made to lines immediately after `name: Prepare E2E reports for Pages` (line 142), inserting:

```yaml
permissions:
  contents: read
```

No other code, steps, or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
