### PR TITLE
bootstrap: add rate limiting module structure (PRD-017)

### DIFF
--- a/e2e/features/ratelimit.feature
+++ b/e2e/features/ratelimit.feature
@@ -1,0 +1,245 @@
+Feature: Rate Limiting & Abuse Prevention
+    As a system operator
+    I want to rate limit requests per IP and user
+    So that brute force attacks and abuse are prevented
+
+  # Per PRD-017: Rate Limiting & Abuse Prevention
+
+  Background:
+    Given the ID Gateway is running
+
+  # ============================================================
+  # FR-1: Per-IP Rate Limiting
+  # ============================================================
+
+  @ratelimit @ip @prd-017
+  Scenario: IP rate limit headers present in response
+    When I make a request to "/auth/userinfo" with valid token
+    Then the response should contain header "X-RateLimit-Limit"
+    And the response should contain header "X-RateLimit-Remaining"
+    And the response should contain header "X-RateLimit-Reset"
+
+  @ratelimit @ip @prd-017
+  Scenario: IP rate limit enforced on auth endpoint (10 req/min)
+    Given I am making requests from IP "192.168.1.50"
+    When I make 10 requests to "/auth/authorize" within 1 minute
+    Then all 10 requests should succeed with status 200
+    When I make the 11th request to "/auth/authorize"
+    Then the response status should be 429
+    And the response field "error" should equal "rate_limit_exceeded"
+    And the response should contain header "Retry-After"
+
+  @ratelimit @ip @prd-017
+  Scenario: IP rate limit enforced on sensitive endpoints (30 req/min)
+    Given I am making requests from IP "192.168.1.51"
+    When I make 30 requests to "/consent" within 1 minute
+    Then all 30 requests should succeed
+    When I make the 31st request to "/consent"
+    Then the response status should be 429
+
+  @ratelimit @ip @prd-017
+  Scenario: IP rate limit enforced on read endpoints (100 req/min)
+    Given I am making requests from IP "192.168.1.52"
+    When I make 100 requests to "/auth/userinfo" within 1 minute
+    Then all 100 requests should succeed
+    When I make the 101st request to "/auth/userinfo"
+    Then the response status should be 429
+
+  @ratelimit @ip @prd-017
+  Scenario: Rate limit resets after window expires
+    Given I am making requests from IP "192.168.1.53"
+    And I have exhausted the rate limit on "/auth/authorize"
+    When I wait for the rate limit window to expire
+    And I make a request to "/auth/authorize"
+    Then the response status should be 200
+
+  # ============================================================
+  # FR-2: Per-User Rate Limiting
+  # ============================================================
+
+  @ratelimit @user @prd-017
+  Scenario: User rate limit enforced on consent operations (50 req/hour)
+    Given I am authenticated as user "test-user-1"
+    When I make 50 consent requests within 1 hour
+    Then all 50 requests should succeed
+    When I make the 51st consent request
+    Then the response status should be 429
+    And the response field "error" should equal "user_rate_limit_exceeded"
+    And the response field "quota_limit" should equal 50
+    And the response field "quota_remaining" should equal 0
+
+  @ratelimit @user @prd-017
+  Scenario: User rate limit for VC issuance (20 req/hour)
+    Given I am authenticated as user "test-user-2"
+    When I make 20 VC issuance requests within 1 hour
+    Then all 20 requests should succeed
+    When I make the 21st VC issuance request
+    Then the response status should be 429
+
+  @ratelimit @user @prd-017
+  Scenario: Both IP and user limits must pass
+    Given I am authenticated as user "test-user-3"
+    And I am making requests from IP "192.168.1.60"
+    When the IP limit is not exceeded
+    And the user limit is exceeded
+    Then the request should be rejected with 429
+
+  # ============================================================
+  # FR-2b: Authentication-Specific Protections (OWASP)
+  # ============================================================
+
+  @ratelimit @auth @owasp @prd-017
+  Scenario: Auth lockout after failed attempts (5 attempts/15 min)
+    Given I am attempting login for user "locked-user@example.com" from IP "192.168.1.70"
+    When I fail authentication 5 times within 15 minutes
+    Then the 6th attempt should return 429
+    And the response should indicate lockout
+
+  @ratelimit @auth @owasp @prd-017
+  Scenario: Hard lockout after 10 daily failures
+    Given I am attempting login for user "hardlock@example.com" from IP "192.168.1.71"
+    When I fail authentication 10 times within 24 hours
+    Then the account should be hard locked for 15 minutes
+    And the audit event "auth.lockout" should be emitted
+
+  @ratelimit @auth @owasp @prd-017
+  Scenario: Progressive backoff on auth failures
+    Given I am attempting login for user "backoff@example.com" from IP "192.168.1.72"
+    When I fail authentication once
+    Then the next response should be delayed by at least 250ms
+    When I fail authentication again
+    Then the next response should be delayed by at least 500ms
+
+  @ratelimit @auth @owasp @prd-017
+  Scenario: Generic error messages prevent enumeration
+    When I attempt login with invalid username "nonexistent@example.com"
+    Then the response error message should be generic
+    When I attempt login with valid username but invalid password
+    Then the response error message should be the same generic message
+
+  @ratelimit @auth @owasp @prd-017
+  Scenario: CAPTCHA required after consecutive lockouts
+    Given user "captcha@example.com" has been locked out 3 times in 24 hours
+    When I attempt to login as "captcha@example.com"
+    Then the response should indicate CAPTCHA is required
+
+  # ============================================================
+  # FR-3: Sliding Window Algorithm
+  # ============================================================
+
+  @ratelimit @algorithm @prd-017
+  Scenario: Sliding window prevents boundary attacks
+    Given I am making requests from IP "192.168.1.80"
+    And the rate limit is 10 requests per minute
+    When I make 10 requests at second 59 of minute 1
+    And I make 5 requests at second 1 of minute 2
+    Then only 5 of the second batch should succeed
+    # Fixed window would allow all 15 (10 at end + 10 at start)
+
+  # ============================================================
+  # FR-4: Rate Limit Bypass (Allowlist)
+  # ============================================================
+
+  @ratelimit @allowlist @admin @prd-017
+  Scenario: Admin can add IP to allowlist
+    Given I am authenticated as admin
+    When I add IP "10.0.0.100" to the rate limit allowlist with reason "Internal monitoring"
+    Then the response should confirm allowlisting
+    And the audit event "rate_limit_allowlist_added" should be emitted
+
+  @ratelimit @allowlist @prd-017
+  Scenario: Allowlisted IP bypasses rate limits
+    Given IP "10.0.0.100" is on the allowlist
+    When I make 200 requests from IP "10.0.0.100" to "/auth/authorize"
+    Then all 200 requests should succeed
+    And no rate limit headers should indicate limit exceeded
+
+  @ratelimit @allowlist @prd-017
+  Scenario: Allowlist entry with expiration
+    Given I am authenticated as admin
+    When I add IP "10.0.0.101" to allowlist with expiration in 1 hour
+    Then the allowlist entry should have expires_at set
+    When the allowlist entry expires
+    Then requests from IP "10.0.0.101" should be rate limited normally
+
+  @ratelimit @allowlist @admin @prd-017
+  Scenario: Admin can remove from allowlist
+    Given IP "10.0.0.100" is on the allowlist
+    And I am authenticated as admin
+    When I remove IP "10.0.0.100" from the allowlist
+    Then the IP should no longer be allowlisted
+    And requests from that IP should be rate limited
+
+  # ============================================================
+  # FR-5: Partner API Quotas (API Keys)
+  # ============================================================
+
+  @ratelimit @quota @partner @prd-017 @simulation
+  Scenario: Free tier quota enforcement (1000 req/month)
+    Given API key "partner-free-123" has tier "free"
+    When the API key has made 1000 requests this month
+    And I make another request with the API key
+    Then the response status should be 429
+    And the response should indicate quota exceeded
+
+  @ratelimit @quota @partner @prd-017 @simulation
+  Scenario: Starter tier with overage allowed
+    Given API key "partner-starter-456" has tier "starter"
+    When the API key has made 10000 requests this month
+    And I make another request with the API key
+    Then the request should succeed
+    And overage should be recorded for billing
+
+  @ratelimit @quota @partner @prd-017 @simulation
+  Scenario: Quota headers present in response
+    Given API key "partner-business-789" has tier "business"
+    When I make a request with the API key
+    Then the response should contain header "X-Quota-Limit"
+    And the response should contain header "X-Quota-Remaining"
+    And the response should contain header "X-Quota-Reset"
+
+  # ============================================================
+  # FR-6: DDoS Protection (Global Throttling)
+  # ============================================================
+
+  @ratelimit @ddos @prd-017 @simulation
+  Scenario: Global throttle returns 503 when exceeded
+    Given the global request rate exceeds 10000 req/sec
+    When I make a request
+    Then the response status should be 503
+    And the response field "error" should equal "service_unavailable"
+    And the response should contain header "Retry-After"
+
+  # ============================================================
+  # Audit Events
+  # ============================================================
+
+  @ratelimit @audit @prd-017
+  Scenario: Rate limit violation emits audit event
+    Given I am making requests from IP "192.168.1.90"
+    When I exceed the rate limit on "/auth/authorize"
+    Then the audit event "rate_limit_exceeded" should be emitted
+    And the audit event should contain the IP address
+    And the audit event should contain the endpoint class
+
+  # ============================================================
+  # Admin Reset Operations
+  # ============================================================
+
+  @ratelimit @admin @prd-017
+  Scenario: Admin can reset rate limit for IP
+    Given IP "192.168.1.95" has exceeded its rate limit
+    And I am authenticated as admin
+    When I reset the rate limit for IP "192.168.1.95"
+    Then the next request from that IP should succeed
+    And the audit event "rate_limit_reset" should be emitted
+
+  # ============================================================
+  # Configuration
+  # ============================================================
+
+  @ratelimit @config @prd-017 @simulation
+  Scenario: Rate limits configurable via environment
+    Given rate limits are configured via environment variables
+    Then the auth endpoint limit should match RATELIMIT_AUTH_LIMIT
+    And the read endpoint limit should match RATELIMIT_READ_LIMIT

--- a/internal/ratelimit/DDD.md
+++ b/internal/ratelimit/DDD.md
@@ -1,0 +1,232 @@
+# DDD in the Rate Limiting Module
+
+This document describes the Domain-Driven Design approach for the `internal/ratelimit` bounded context in Credo, implementing PRD-017: Rate Limiting & Abuse Prevention.
+
+---
+
+## 1) Bounded Context Definition
+
+**Context:** `internal/ratelimit`
+
+**Purpose:** Implement rate limiting and abuse prevention to protect the platform from:
+
+- Brute force attacks on authentication endpoints
+- Credential stuffing attacks
+- DDoS and resource exhaustion
+- API abuse and cost attacks
+- Account enumeration
+
+This is a distinct bounded context because rate limiting has its own vocabulary and invariants separate from authentication or authorization.
+
+---
+
+## 2) Ubiquitous Language Mapping
+
+| Term | Code Location | Description |
+|------|---------------|-------------|
+| **Rate Limit** | `models.RateLimitResult` | The maximum requests allowed in a time window |
+| **Endpoint Class** | `models.EndpointClass` | Category of endpoints (auth, sensitive, read, write) |
+| **Sliding Window** | `store/bucket` | Algorithm for fair rate limiting without boundary attacks |
+| **Allowlist** | `models.AllowlistEntry` | IPs or users exempt from rate limits |
+| **Lockout** | `models.AuthLockout` | Temporary block after repeated auth failures |
+| **Quota** | `models.APIKeyQuota` | Monthly request allocation for partner APIs |
+| **Global Throttle** | `service.CheckGlobalThrottle` | DDoS protection via system-wide limits |
+
+---
+
+## 3) Domain Model
+
+### Entities
+
+- **AllowlistEntry**: Has identity (ID), lifecycle (expiration), tracks who created it and why
+- **AuthLockout**: Tracks lockout state for an identifier, has temporal lifecycle
+- **APIKeyQuota**: Tracks quota usage for a partner API key over a billing period
+
+### Value Objects
+
+- **EndpointClass**: Categorizes endpoints for differentiated limits (`auth`, `sensitive`, `read`, `write`)
+- **RateLimitResult**: Immutable result of a rate limit check (allowed, remaining, reset time)
+- **QuotaTier**: Partner API tier (`free`, `starter`, `business`, `enterprise`)
+
+### Aggregate Roots
+
+The rate limiting domain doesn't have traditional aggregates since state is transient (counters with TTL). However:
+
+- **Rate limit counters** (sliding windows) are the primary stateful concept
+- **Allowlist** manages a collection of AllowlistEntry entities
+
+---
+
+## 4) Domain Invariants vs API Input Rules
+
+### Domain Invariants (must always hold)
+
+- `AllowlistEntry.Identifier` cannot be empty
+- `AllowlistEntry.Type` must be "ip" or "user_id"
+- `AllowlistEntry.Reason` cannot be empty (audit requirement)
+- Rate limit `Remaining` cannot be negative
+- `AuthLockout.LockedUntil` if set, must be in the future when lockout is active
+
+### API Input Rules (can change without data migration)
+
+- IP format validation for allowlist
+- UUID format for user_id allowlist entries
+- ExpiresAt must be in the future when provided
+- Rate limit values (requests per window) are configurable
+- Progressive backoff timing (250ms → 500ms → 1s) is policy
+
+---
+
+## 5) Module Structure
+
+```
+internal/ratelimit/
+├── DDD.md                    # This document
+├── models/
+│   ├── models.go             # Domain entities and value objects
+│   ├── requests.go           # API request DTOs
+│   └── responses.go          # API response DTOs
+├── service/
+│   ├── interfaces.go         # Store interfaces (BucketStore, AllowlistStore, etc.)
+│   ├── config.go             # Configuration with defaults per PRD-017
+│   ├── service.go            # Application service (orchestration)
+│   └── service_test.go       # Service tests
+├── store/
+│   ├── bucket/
+│   │   ├── store_memory.go   # In-memory sliding window (MVP)
+│   │   └── store_memory_test.go
+│   └── allowlist/
+│       ├── store_memory.go   # In-memory allowlist (MVP)
+│       └── store_memory_test.go
+├── handler/
+│   └── handler.go            # HTTP handlers for admin endpoints
+└── middleware/
+    └── ratelimit.go          # HTTP middleware for rate limiting
+```
+
+---
+
+## 6) Layering
+
+Following `AGENTS.md` rules:
+
+### Middleware (`middleware/ratelimit.go`)
+- HTTP concern: Extract IP, user ID from context
+- Call service for rate limit checks
+- Add rate limit headers to responses
+- Return 429/503 when limits exceeded
+
+### Handlers (`handler/handler.go`)
+- HTTP concern: Parse JSON requests
+- Call service for admin operations
+- Map responses
+
+### Service (`service/service.go`)
+- Orchestration: Check allowlist, then rate limit
+- Domain behavior: Progressive backoff calculation
+- Error mapping: Internal errors → domain errors
+- Audit: Emit events on violations and admin actions
+
+### Stores (`store/`)
+- Persistence: Sliding window counters, allowlist entries
+- Return domain models, not persistence structs
+
+---
+
+## 7) Integration Points
+
+### Consumes
+- `internal/platform/middleware`: Extract client IP, user ID, request ID from context
+- `internal/audit`: Emit audit events for violations
+- `pkg/domain-errors`: Domain error codes
+
+### Consumed By
+- Router middleware chain: Apply rate limiting to all routes
+- Auth module: Authentication-specific lockout integration
+- Admin module: Allowlist management endpoints
+
+---
+
+## 8) Key Design Decisions
+
+### Sliding Window over Token Bucket
+- PRD-017 specifies sliding window to prevent boundary attacks
+- More accurate rate distribution than fixed windows
+- Redis implementation uses sorted sets for O(log N) complexity
+
+### Composite Keys for Auth Lockout
+- Per OWASP guidance: `{email}:{ip}` composite key
+- Prevents attackers from trying different emails from same IP
+- Prevents distributed attacks on single email
+
+### Allowlist Before Rate Limit
+- Allowlist check happens first (short-circuit for monitoring/internal services)
+- Reduces load on rate limit stores for known-good traffic
+
+### Progressive Backoff in Service Layer
+- Backoff delays are applied in service, not middleware
+- Allows for future async response patterns
+- Keeps middleware focused on pass/fail decisions
+
+---
+
+## 9) Future Considerations
+
+### Redis Implementation
+- Replace in-memory stores with Redis for distributed deployments
+- Lua scripts for atomic sliding window operations
+- Separate Redis instance or cluster for rate limiting
+
+### Adaptive Rate Limiting
+- Lower limits automatically during detected attacks
+- ML-based anomaly detection (PRD-023)
+
+### Per-Endpoint Custom Limits
+- Currently limits by class; may need per-endpoint overrides
+- Consider endpoint registry with custom limits
+
+---
+
+## 10) PRD-017 Requirements Mapping
+
+| Requirement | Implementation |
+|-------------|----------------|
+| FR-1: Per-IP Rate Limiting | `service.CheckIPRateLimit`, `middleware.RateLimit` |
+| FR-2: Per-User Rate Limiting | `service.CheckUserRateLimit`, `middleware.RateLimitAuthenticated` |
+| FR-2b: Auth Protections | `service.CheckAuthRateLimit`, `models.AuthLockout` |
+| FR-3: Sliding Window | `store/bucket/store_memory.go` |
+| FR-4: Allowlist Bypass | `store/allowlist`, `handler.HandleAddAllowlist` |
+| FR-5: Partner Quotas | `models.APIKeyQuota`, `service.CheckAPIKeyQuota` |
+| FR-6: Global Throttle | `service.CheckGlobalThrottle`, `middleware.GlobalThrottle` |
+| TR-1: RateLimiter Interface | `service/interfaces.go` |
+| TR-3: Middleware | `middleware/ratelimit.go` |
+| TR-4: Configuration | `service/config.go` |
+
+---
+
+## 11) Implementation Status
+
+### Completed (Stubs)
+- [x] Domain models
+- [x] Service interfaces
+- [x] Service stub with method signatures
+- [x] In-memory store stubs
+- [x] Handler stubs
+- [x] Middleware stubs
+- [x] Feature file (Gherkin scenarios)
+- [x] Test stubs
+
+### TODO (Implementation)
+- [ ] `InMemoryBucketStore.Allow` - sliding window algorithm
+- [ ] `InMemoryAllowlistStore` - CRUD operations
+- [ ] `Service.CheckIPRateLimit` - orchestration
+- [ ] `Service.CheckUserRateLimit` - orchestration
+- [ ] `Service.CheckBothLimits` - combined check
+- [ ] `Service.CheckAuthRateLimit` - with lockout
+- [ ] `Service.RecordAuthFailure` - lockout tracking
+- [ ] `Service.GetProgressiveBackoff` - backoff calculation
+- [ ] `Service.AddToAllowlist` - admin operation
+- [ ] `Middleware.RateLimit` - apply to routes
+- [ ] Handler implementations
+- [ ] Cucumber step definitions
+- [ ] Redis implementation (Phase 2)

--- a/internal/ratelimit/README.md
+++ b/internal/ratelimit/README.md
@@ -1,0 +1,165 @@
+# Rate Limiting Module
+
+Implementation of PRD-017: Rate Limiting & Abuse Prevention.
+
+## Overview
+
+This module provides rate limiting and abuse prevention for the Credo platform:
+
+- **Per-IP rate limiting** with configurable limits by endpoint class
+- **Per-user rate limiting** for authenticated endpoints
+- **Authentication-specific protections** following OWASP guidelines
+- **Allowlist management** for bypassing rate limits
+- **Partner API quotas** for monthly usage tracking
+- **Global throttling** for DDoS protection
+
+## Module Structure
+
+```
+internal/ratelimit/
+├── models/           # Domain models, requests, responses
+├── service/          # Business logic and orchestration
+├── store/            # Persistence (in-memory, Redis)
+│   ├── bucket/       # Rate limit counters (sliding window)
+│   └── allowlist/    # Allowlist entries
+├── handler/          # HTTP handlers for admin endpoints
+├── middleware/       # HTTP middleware for rate limiting
+├── DDD.md           # Domain-Driven Design documentation
+└── README.md        # This file
+```
+
+## Quick Start
+
+### Apply middleware to routes
+
+```go
+import (
+    rlMiddleware "credo/internal/ratelimit/middleware"
+    rlService "credo/internal/ratelimit/service"
+    "credo/internal/ratelimit/store/bucket"
+    "credo/internal/ratelimit/store/allowlist"
+)
+
+// Create stores
+bucketStore := bucket.NewInMemoryBucketStore()
+allowlistStore := allowlist.NewInMemoryAllowlistStore()
+
+// Create service
+svc, _ := rlService.New(bucketStore, allowlistStore)
+
+// Create middleware
+mw := rlMiddleware.New(svc, logger)
+
+// Apply to routes
+r.With(mw.RateLimit(models.ClassAuth)).Post("/auth/authorize", authHandler)
+r.With(mw.RateLimitAuthenticated(models.ClassRead)).Get("/auth/userinfo", userinfoHandler)
+```
+
+### Register admin endpoints
+
+```go
+import rlHandler "credo/internal/ratelimit/handler"
+
+handler := rlHandler.New(svc, logger)
+handler.RegisterAdmin(adminRouter)
+```
+
+## Rate Limit Tiers
+
+### Per-IP Limits (PRD-017 FR-1)
+
+| Endpoint Class | Rate Limit | Window | Example Endpoints |
+|----------------|------------|--------|-------------------|
+| `auth` | 10 req/min | 1 min | `/auth/authorize`, `/auth/token` |
+| `sensitive` | 30 req/min | 1 min | `/consent`, `/vc/issue` |
+| `read` | 100 req/min | 1 min | `/auth/userinfo` |
+| `write` | 50 req/min | 1 min | General mutations |
+
+### Per-User Limits (PRD-017 FR-2)
+
+| Endpoint Class | Rate Limit | Window |
+|----------------|------------|--------|
+| Consent Operations | 50 req/hour | 1 hour |
+| VC Issuance | 20 req/hour | 1 hour |
+| Decision Evaluations | 200 req/hour | 1 hour |
+| Data Export | 5 req/hour | 1 hour |
+
+## Response Headers
+
+All responses include rate limit headers:
+
+```
+X-RateLimit-Limit: 10
+X-RateLimit-Remaining: 7
+X-RateLimit-Reset: 1735934400
+```
+
+When rate limit is exceeded (429 response):
+
+```
+Retry-After: 45
+```
+
+## Admin API
+
+### Add to Allowlist
+
+```bash
+POST /admin/rate-limit/allowlist
+{
+  "type": "ip",
+  "identifier": "192.168.1.100",
+  "reason": "Internal monitoring service",
+  "expires_at": "2025-12-31T23:59:59Z"
+}
+```
+
+### Remove from Allowlist
+
+```bash
+DELETE /admin/rate-limit/allowlist
+{
+  "type": "ip",
+  "identifier": "192.168.1.100"
+}
+```
+
+### Reset Rate Limit
+
+```bash
+POST /admin/rate-limit/reset
+{
+  "type": "ip",
+  "identifier": "192.168.1.100",
+  "class": "auth"
+}
+```
+
+## Implementation Status
+
+This module is **bootstrapped with stubs**. The following needs implementation:
+
+- [ ] Sliding window algorithm in `store/bucket`
+- [ ] Allowlist CRUD in `store/allowlist`
+- [ ] Service methods (check limits, record failures, etc.)
+- [ ] Middleware implementation
+- [ ] Handler implementations
+- [ ] Cucumber step definitions in `e2e/steps/ratelimit`
+
+See `DDD.md` for detailed implementation guidance.
+
+## Testing
+
+```bash
+# Run unit tests
+go test ./internal/ratelimit/...
+
+# Run feature tests (after implementing step definitions)
+cd e2e && go test -v -tags=e2e
+```
+
+## References
+
+- [PRD-017: Rate Limiting & Abuse Prevention](../../docs/prd/PRD-017-Rate-Limiting-Abuse-Prevention.md)
+- [IETF RateLimit Header Draft](https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-ratelimit-headers)
+- [OWASP Authentication Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html)

--- a/internal/ratelimit/handler/handler.go
+++ b/internal/ratelimit/handler/handler.go
@@ -1,0 +1,169 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"credo/internal/platform/middleware"
+	"credo/internal/ratelimit/models"
+	httpError "credo/internal/transport/http/error"
+	jsonResponse "credo/internal/transport/http/json"
+	dErrors "credo/pkg/domain-errors"
+)
+
+// Service defines the interface for rate limiting operations.
+// Handlers depend on this interface, not the concrete service.
+type Service interface {
+	// Allowlist management (admin operations)
+	AddToAllowlist(ctx context.Context, req *models.AddAllowlistRequest, adminUserID string) (*models.AllowlistEntry, error)
+	RemoveFromAllowlist(ctx context.Context, req *models.RemoveAllowlistRequest) error
+	ListAllowlist(ctx context.Context) ([]*models.AllowlistEntry, error)
+
+	// Admin operations
+	ResetRateLimit(ctx context.Context, req *models.ResetRateLimitRequest) error
+}
+
+// Handler handles rate limit admin endpoints.
+// Per PRD-017 FR-4: Admin endpoints for allowlist management.
+type Handler struct {
+	service Service
+	logger  *slog.Logger
+}
+
+// New creates a new rate limit Handler.
+func New(service Service, logger *slog.Logger) *Handler {
+	return &Handler{
+		service: service,
+		logger:  logger,
+	}
+}
+
+// RegisterAdmin registers admin routes for rate limit management.
+// Per PRD-017 FR-4: POST /admin/rate-limit/allowlist
+func (h *Handler) RegisterAdmin(r chi.Router) {
+	r.Post("/admin/rate-limit/allowlist", h.HandleAddAllowlist)
+	r.Delete("/admin/rate-limit/allowlist", h.HandleRemoveAllowlist)
+	r.Get("/admin/rate-limit/allowlist", h.HandleListAllowlist)
+	r.Post("/admin/rate-limit/reset", h.HandleResetRateLimit)
+}
+
+// HandleAddAllowlist implements POST /admin/rate-limit/allowlist.
+// Per PRD-017 FR-4: Add IP or user to allowlist.
+//
+// Input: { "type": "ip", "identifier": "192.168.1.100", "reason": "...", "expires_at": "..." }
+// Output: { "allowlisted": true, "identifier": "192.168.1.100", "expires_at": "..." }
+//
+// TODO: Implement this handler
+// 1. Decode JSON request body
+// 2. Validate request
+// 3. Get admin user ID from context (set by auth middleware)
+// 4. Call service.AddToAllowlist
+// 5. Return AllowlistEntryResponse
+func (h *Handler) HandleAddAllowlist(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	requestID := middleware.GetRequestID(ctx)
+
+	var req models.AddAllowlistRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.logger.WarnContext(ctx, "failed to decode add allowlist request",
+			"error", err,
+			"request_id", requestID,
+		)
+		httpError.WriteError(w, dErrors.New(dErrors.CodeBadRequest, "Invalid JSON in request body"))
+		return
+	}
+
+	// TODO: Implement - validate request, get admin user ID, call service
+	// adminUserID := middleware.GetUserID(ctx)
+	// entry, err := h.service.AddToAllowlist(ctx, &req, adminUserID)
+	// if err != nil { ... }
+	// jsonResponse.WriteJSON(w, http.StatusOK, &models.AllowlistEntryResponse{...})
+
+	httpError.WriteError(w, dErrors.New(dErrors.CodeInternal, "not implemented"))
+}
+
+// HandleRemoveAllowlist implements DELETE /admin/rate-limit/allowlist.
+// Per PRD-017 FR-4: Remove IP or user from allowlist.
+//
+// Input: { "type": "ip", "identifier": "192.168.1.100" }
+// Output: 204 No Content
+//
+// TODO: Implement this handler
+func (h *Handler) HandleRemoveAllowlist(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	requestID := middleware.GetRequestID(ctx)
+
+	var req models.RemoveAllowlistRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.logger.WarnContext(ctx, "failed to decode remove allowlist request",
+			"error", err,
+			"request_id", requestID,
+		)
+		httpError.WriteError(w, dErrors.New(dErrors.CodeBadRequest, "Invalid JSON in request body"))
+		return
+	}
+
+	// TODO: Implement - validate request, call service
+	// err := h.service.RemoveFromAllowlist(ctx, &req)
+	// if err != nil { ... }
+	// w.WriteHeader(http.StatusNoContent)
+
+	httpError.WriteError(w, dErrors.New(dErrors.CodeInternal, "not implemented"))
+}
+
+// HandleListAllowlist implements GET /admin/rate-limit/allowlist.
+// Returns all active allowlist entries.
+//
+// Output: [{ "type": "ip", "identifier": "...", ... }, ...]
+//
+// TODO: Implement this handler
+func (h *Handler) HandleListAllowlist(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	requestID := middleware.GetRequestID(ctx)
+
+	// TODO: Implement
+	// entries, err := h.service.ListAllowlist(ctx)
+	// if err != nil { ... }
+	// jsonResponse.WriteJSON(w, http.StatusOK, entries)
+
+	h.logger.InfoContext(ctx, "list allowlist called", "request_id", requestID)
+	httpError.WriteError(w, dErrors.New(dErrors.CodeInternal, "not implemented"))
+}
+
+// HandleResetRateLimit implements POST /admin/rate-limit/reset.
+// Per PRD-017 TR-1: Admin reset operation.
+//
+// Input: { "type": "ip", "identifier": "192.168.1.100", "class": "auth" }
+// Output: 204 No Content
+//
+// TODO: Implement this handler
+func (h *Handler) HandleResetRateLimit(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	requestID := middleware.GetRequestID(ctx)
+
+	var req models.ResetRateLimitRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.logger.WarnContext(ctx, "failed to decode reset rate limit request",
+			"error", err,
+			"request_id", requestID,
+		)
+		httpError.WriteError(w, dErrors.New(dErrors.CodeBadRequest, "Invalid JSON in request body"))
+		return
+	}
+
+	// TODO: Implement
+	// err := h.service.ResetRateLimit(ctx, &req)
+	// if err != nil { ... }
+	// w.WriteHeader(http.StatusNoContent)
+
+	httpError.WriteError(w, dErrors.New(dErrors.CodeInternal, "not implemented"))
+}
+
+// Ensure Handler has no unused imports
+var (
+	_ = jsonResponse.WriteJSON
+)

--- a/internal/ratelimit/middleware/ratelimit.go
+++ b/internal/ratelimit/middleware/ratelimit.go
@@ -1,0 +1,248 @@
+package middleware
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	platformMW "credo/internal/platform/middleware"
+	"credo/internal/ratelimit/models"
+	jsonResponse "credo/internal/transport/http/json"
+)
+
+// RateLimiter defines the interface for rate limit checking.
+// This is implemented by the ratelimit service.
+type RateLimiter interface {
+	// CheckIPRateLimit checks IP-based rate limit
+	CheckIPRateLimit(ctx context.Context, ip string, class models.EndpointClass) (*models.RateLimitResult, error)
+
+	// CheckUserRateLimit checks user-based rate limit
+	CheckUserRateLimit(ctx context.Context, userID string, class models.EndpointClass) (*models.RateLimitResult, error)
+
+	// CheckBothLimits checks both IP and user limits (both must pass)
+	CheckBothLimits(ctx context.Context, ip, userID string, class models.EndpointClass) (*models.RateLimitResult, error)
+
+	// CheckAuthRateLimit checks auth-specific limits with lockout
+	CheckAuthRateLimit(ctx context.Context, identifier, ip string) (*models.RateLimitResult, error)
+
+	// CheckGlobalThrottle checks global DDoS throttle
+	CheckGlobalThrottle(ctx context.Context) (bool, error)
+}
+
+// Middleware provides HTTP middleware for rate limiting.
+// Per PRD-017 TR-3: Middleware implementation.
+type Middleware struct {
+	limiter RateLimiter
+	logger  *slog.Logger
+}
+
+// New creates a new rate limit Middleware.
+func New(limiter RateLimiter, logger *slog.Logger) *Middleware {
+	return &Middleware{
+		limiter: limiter,
+		logger:  logger,
+	}
+}
+
+// RateLimit returns middleware that enforces per-IP rate limiting.
+// Per PRD-017 FR-1, TR-3: Per-IP rate limiting middleware.
+//
+// TODO: Implement this middleware
+// 1. Extract client IP from context (set by ClientMetadata middleware)
+// 2. Check if allowlisted (via limiter)
+// 3. Call limiter.CheckIPRateLimit
+// 4. Add rate limit headers to response
+// 5. If not allowed, return 429 with retry-after
+// 6. Else call next handler
+func (m *Middleware) RateLimit(class models.EndpointClass) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			ip := platformMW.GetClientIP(ctx)
+
+			// TODO: Implement rate limit check
+			// result, err := m.limiter.CheckIPRateLimit(ctx, ip, class)
+			// if err != nil { ... log and allow through ... }
+			//
+			// Add headers regardless of outcome
+			// addRateLimitHeaders(w, result)
+			//
+			// if !result.Allowed {
+			//     writeRateLimitExceeded(w, result)
+			//     return
+			// }
+
+			_ = ip // Remove when implemented
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// RateLimitAuthenticated returns middleware that enforces both IP and user rate limits.
+// Per PRD-017 FR-2: Both limits must pass for authenticated endpoints.
+//
+// TODO: Implement this middleware
+// 1. Extract client IP and user ID from context
+// 2. Call limiter.CheckBothLimits
+// 3. Add rate limit headers (use the more restrictive values)
+// 4. If not allowed, return 429 with appropriate message
+// 5. Else call next handler
+func (m *Middleware) RateLimitAuthenticated(class models.EndpointClass) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			ip := platformMW.GetClientIP(ctx)
+			userID := platformMW.GetUserID(ctx)
+
+			// TODO: Implement combined rate limit check
+			// result, err := m.limiter.CheckBothLimits(ctx, ip, userID, class)
+			// if err != nil { ... log and allow through ... }
+			//
+			// addRateLimitHeaders(w, result)
+			//
+			// if !result.Allowed {
+			//     writeUserRateLimitExceeded(w, result)
+			//     return
+			// }
+
+			_ = ip
+			_ = userID
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// RateLimitAuth returns middleware for authentication endpoints with lockout.
+// Per PRD-017 FR-2b: OWASP authentication-specific protections.
+//
+// TODO: Implement this middleware
+// This is applied to /auth/authorize, /auth/token, /auth/password-reset, /mfa/*
+// 1. Extract client IP from context
+// 2. Extract identifier (email/username) from request body if applicable
+// 3. Call limiter.CheckAuthRateLimit
+// 4. Apply progressive backoff delay if configured
+// 5. If locked out, return 429 with lockout info
+// 6. Else call next handler
+func (m *Middleware) RateLimitAuth() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			ip := platformMW.GetClientIP(ctx)
+
+			// TODO: Implement auth rate limit with lockout
+			// Note: May need to peek at request body to get email/username
+			// result, err := m.limiter.CheckAuthRateLimit(ctx, "", ip)
+			// if err != nil { ... }
+			//
+			// addRateLimitHeaders(w, result)
+			//
+			// if !result.Allowed {
+			//     writeAuthLockout(w, result)
+			//     return
+			// }
+
+			_ = ip
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// GlobalThrottle returns middleware for global DDoS protection.
+// Per PRD-017 FR-6: Global request throttling.
+//
+// TODO: Implement this middleware
+// 1. Call limiter.CheckGlobalThrottle
+// 2. If throttled, return 503 Service Unavailable
+// 3. Else call next handler
+func (m *Middleware) GlobalThrottle() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+
+			// TODO: Implement global throttle
+			// allowed, err := m.limiter.CheckGlobalThrottle(ctx)
+			// if err != nil { ... log and allow through ... }
+			//
+			// if !allowed {
+			//     writeServiceOverloaded(w)
+			//     return
+			// }
+
+			_ = ctx
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// addRateLimitHeaders adds X-RateLimit-* headers to the response.
+// Per PRD-017 FR-1: Standard rate limit headers.
+//
+// TODO: Implement this helper
+// Headers:
+// - X-RateLimit-Limit: {limit}
+// - X-RateLimit-Remaining: {remaining}
+// - X-RateLimit-Reset: {unix timestamp}
+func addRateLimitHeaders(w http.ResponseWriter, result *models.RateLimitResult) {
+	if result == nil {
+		return
+	}
+	w.Header().Set("X-RateLimit-Limit", strconv.Itoa(result.Limit))
+	w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(result.Remaining))
+	w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(result.ResetAt.Unix(), 10))
+}
+
+// writeRateLimitExceeded writes a 429 response for IP rate limit exceeded.
+// Per PRD-017 FR-1: 429 response format.
+//
+// TODO: Implement this helper
+func writeRateLimitExceeded(w http.ResponseWriter, result *models.RateLimitResult) {
+	w.Header().Set("Retry-After", strconv.Itoa(result.RetryAfter))
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusTooManyRequests)
+	jsonResponse.WriteJSON(w, http.StatusTooManyRequests, &models.RateLimitExceededResponse{
+		Error:      "rate_limit_exceeded",
+		Message:    "Too many requests from this IP address. Please try again later.",
+		RetryAfter: result.RetryAfter,
+	})
+}
+
+// writeUserRateLimitExceeded writes a 429 response for user rate limit exceeded.
+// Per PRD-017 FR-2: User-specific rate limit response.
+//
+// TODO: Implement this helper
+func writeUserRateLimitExceeded(w http.ResponseWriter, result *models.RateLimitResult) {
+	w.Header().Set("Retry-After", strconv.Itoa(result.RetryAfter))
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusTooManyRequests)
+	jsonResponse.WriteJSON(w, http.StatusTooManyRequests, &models.UserRateLimitExceededResponse{
+		Error:          "user_rate_limit_exceeded",
+		Message:        "You have exceeded your request quota for this operation.",
+		QuotaLimit:     result.Limit,
+		QuotaRemaining: result.Remaining,
+		QuotaReset:     result.ResetAt,
+	})
+}
+
+// writeServiceOverloaded writes a 503 response for global throttle exceeded.
+// Per PRD-017 FR-6: 503 response for DDoS protection.
+//
+// TODO: Implement this helper
+func writeServiceOverloaded(w http.ResponseWriter) {
+	w.Header().Set("Retry-After", "60")
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusServiceUnavailable)
+	jsonResponse.WriteJSON(w, http.StatusServiceUnavailable, &models.ServiceOverloadedResponse{
+		Error:      "service_unavailable",
+		Message:    "Service is temporarily overloaded. Please try again later.",
+		RetryAfter: 60,
+	})
+}
+
+// Ensure unused imports are referenced
+var _ = time.Now

--- a/internal/ratelimit/models/models.go
+++ b/internal/ratelimit/models/models.go
@@ -1,0 +1,133 @@
+package models
+
+import (
+	"time"
+
+	dErrors "credo/pkg/domain-errors"
+)
+
+// EndpointClass categorizes endpoints for differentiated rate limiting.
+// Per PRD-017 FR-1: Different endpoint classes have different rate limits.
+type EndpointClass string
+
+const (
+	// ClassAuth: Authentication endpoints (10 req/min) - /auth/authorize, /auth/token
+	ClassAuth EndpointClass = "auth"
+	// ClassSensitive: Sensitive operations (30 req/min) - /consent, /vc/issue, /decision/evaluate
+	ClassSensitive EndpointClass = "sensitive"
+	// ClassRead: Read operations (100 req/min) - /auth/userinfo, /consent, /me/data-export
+	ClassRead EndpointClass = "read"
+	// ClassWrite: Write operations (50 req/min) - general mutations
+	ClassWrite EndpointClass = "write"
+)
+
+// AllowlistEntryType defines whether an allowlist entry is for an IP or user.
+type AllowlistEntryType string
+
+const (
+	AllowlistTypeIP     AllowlistEntryType = "ip"
+	AllowlistTypeUserID AllowlistEntryType = "user_id"
+)
+
+// RateLimitResult represents the outcome of a rate limit check.
+// Per PRD-017 FR-1: Headers include X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset.
+type RateLimitResult struct {
+	Allowed   bool      `json:"allowed"`
+	Limit     int       `json:"limit"`
+	Remaining int       `json:"remaining"`
+	ResetAt   time.Time `json:"reset_at"`
+	RetryAfter int      `json:"retry_after,omitempty"` // seconds, only set when not allowed
+}
+
+// AllowlistEntry represents an IP or user that bypasses rate limits.
+// Per PRD-017 FR-4: Admin can allowlist IPs or users.
+type AllowlistEntry struct {
+	ID         string             `json:"id"`
+	Type       AllowlistEntryType `json:"type"`
+	Identifier string             `json:"identifier"` // IP address or user_id
+	Reason     string             `json:"reason"`
+	ExpiresAt  *time.Time         `json:"expires_at,omitempty"`
+	CreatedAt  time.Time          `json:"created_at"`
+	CreatedBy  string             `json:"created_by"` // admin user_id
+}
+
+// RateLimitViolation represents a recorded rate limit violation for audit.
+// Per PRD-017 FR-1: Emit audit event on rate_limit_exceeded.
+type RateLimitViolation struct {
+	ID            string        `json:"id"`
+	Identifier    string        `json:"identifier"`    // IP or user_id
+	EndpointClass EndpointClass `json:"endpoint_class"`
+	Endpoint      string        `json:"endpoint"`
+	Limit         int           `json:"limit"`
+	WindowSeconds int           `json:"window_seconds"`
+	OccurredAt    time.Time     `json:"occurred_at"`
+}
+
+// QuotaTier represents partner API quota configuration.
+// Per PRD-017 FR-5: Partner API quotas by tier.
+type QuotaTier string
+
+const (
+	QuotaTierFree       QuotaTier = "free"
+	QuotaTierStarter    QuotaTier = "starter"
+	QuotaTierBusiness   QuotaTier = "business"
+	QuotaTierEnterprise QuotaTier = "enterprise"
+)
+
+// APIKeyQuota tracks quota usage for a partner API key.
+// Per PRD-017 FR-5: Track monthly quotas per API key.
+type APIKeyQuota struct {
+	APIKeyID       string    `json:"api_key_id"`
+	Tier           QuotaTier `json:"tier"`
+	MonthlyLimit   int       `json:"monthly_limit"`
+	CurrentUsage   int       `json:"current_usage"`
+	OverageAllowed bool      `json:"overage_allowed"`
+	PeriodStart    time.Time `json:"period_start"`
+	PeriodEnd      time.Time `json:"period_end"`
+}
+
+// AuthLockout tracks authentication-specific lockout state.
+// Per PRD-017 FR-2b: OWASP authentication-specific protections.
+type AuthLockout struct {
+	Identifier      string    `json:"identifier"`      // username/email + IP composite key
+	FailureCount    int       `json:"failure_count"`   // failures in current window
+	DailyFailures   int       `json:"daily_failures"`  // failures today (for hard lock)
+	LockedUntil     *time.Time `json:"locked_until,omitempty"`
+	LastFailureAt   time.Time `json:"last_failure_at"`
+	RequiresCaptcha bool      `json:"requires_captcha"` // after 3 consecutive lockouts in 24h
+}
+
+// NewAllowlistEntry creates an AllowlistEntry with domain invariant validation.
+func NewAllowlistEntry(entryType AllowlistEntryType, identifier, reason, createdBy string, expiresAt *time.Time) (*AllowlistEntry, error) {
+	if identifier == "" {
+		return nil, dErrors.New(dErrors.CodeInvariantViolation, "identifier cannot be empty")
+	}
+	if entryType != AllowlistTypeIP && entryType != AllowlistTypeUserID {
+		return nil, dErrors.New(dErrors.CodeInvariantViolation, "invalid allowlist entry type")
+	}
+	if reason == "" {
+		return nil, dErrors.New(dErrors.CodeInvariantViolation, "reason cannot be empty")
+	}
+	if createdBy == "" {
+		return nil, dErrors.New(dErrors.CodeInvariantViolation, "created_by cannot be empty")
+	}
+
+	// TODO: Implement - generate unique ID
+	return &AllowlistEntry{
+		ID:         "", // TODO: generate UUID
+		Type:       entryType,
+		Identifier: identifier,
+		Reason:     reason,
+		ExpiresAt:  expiresAt,
+		CreatedAt:  time.Now(),
+		CreatedBy:  createdBy,
+	}, nil
+}
+
+// IsExpired checks if the allowlist entry has expired.
+func (e *AllowlistEntry) IsExpired() bool {
+	if e.ExpiresAt == nil {
+		return false
+	}
+	return time.Now().After(*e.ExpiresAt)
+}

--- a/internal/ratelimit/models/requests.go
+++ b/internal/ratelimit/models/requests.go
@@ -1,0 +1,51 @@
+package models
+
+import "time"
+
+// AddAllowlistRequest is the API request for adding an allowlist entry.
+// Per PRD-017 FR-4: POST /admin/rate-limit/allowlist
+type AddAllowlistRequest struct {
+	Type       AllowlistEntryType `json:"type" validate:"required,oneof=ip user_id"`
+	Identifier string             `json:"identifier" validate:"required"`
+	Reason     string             `json:"reason" validate:"required"`
+	ExpiresAt  *time.Time         `json:"expires_at,omitempty"`
+}
+
+// Validate validates the AddAllowlistRequest fields.
+// API input rules - not domain invariants.
+func (r *AddAllowlistRequest) Validate() error {
+	// TODO: Implement validation
+	// - Type must be "ip" or "user_id"
+	// - Identifier must be non-empty
+	// - If Type is "ip", validate IP format
+	// - If Type is "user_id", validate UUID format
+	// - Reason must be non-empty
+	// - ExpiresAt if provided must be in the future
+	return nil
+}
+
+// RemoveAllowlistRequest is the API request for removing an allowlist entry.
+type RemoveAllowlistRequest struct {
+	Type       AllowlistEntryType `json:"type" validate:"required,oneof=ip user_id"`
+	Identifier string             `json:"identifier" validate:"required"`
+}
+
+// Validate validates the RemoveAllowlistRequest fields.
+func (r *RemoveAllowlistRequest) Validate() error {
+	// TODO: Implement validation
+	return nil
+}
+
+// ResetRateLimitRequest is the API request for resetting a rate limit counter.
+// Admin operation per PRD-017 TR-1.
+type ResetRateLimitRequest struct {
+	Type       AllowlistEntryType `json:"type" validate:"required,oneof=ip user_id"`
+	Identifier string             `json:"identifier" validate:"required"`
+	Class      EndpointClass      `json:"class,omitempty"` // optional, reset specific class
+}
+
+// Validate validates the ResetRateLimitRequest fields.
+func (r *ResetRateLimitRequest) Validate() error {
+	// TODO: Implement validation
+	return nil
+}

--- a/internal/ratelimit/models/responses.go
+++ b/internal/ratelimit/models/responses.go
@@ -1,0 +1,45 @@
+package models
+
+import "time"
+
+// RateLimitExceededResponse is the API response when rate limit is exceeded.
+// Per PRD-017 FR-1: 429 response format.
+type RateLimitExceededResponse struct {
+	Error      string `json:"error"`       // "rate_limit_exceeded" or "user_rate_limit_exceeded"
+	Message    string `json:"message"`
+	RetryAfter int    `json:"retry_after"` // seconds
+}
+
+// UserRateLimitExceededResponse is the API response when user quota is exceeded.
+// Per PRD-017 FR-2: User-specific rate limit response.
+type UserRateLimitExceededResponse struct {
+	Error          string    `json:"error"` // "user_rate_limit_exceeded"
+	Message        string    `json:"message"`
+	QuotaLimit     int       `json:"quota_limit"`
+	QuotaRemaining int       `json:"quota_remaining"`
+	QuotaReset     time.Time `json:"quota_reset"`
+}
+
+// AllowlistEntryResponse is the API response for allowlist operations.
+// Per PRD-017 FR-4: Response for allowlist add.
+type AllowlistEntryResponse struct {
+	Allowlisted bool       `json:"allowlisted"`
+	Identifier  string     `json:"identifier"`
+	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
+}
+
+// QuotaResponse is the API response with quota headers info.
+// Per PRD-017 FR-5: X-Quota-* headers.
+type QuotaResponse struct {
+	QuotaLimit     int       `json:"quota_limit"`
+	QuotaRemaining int       `json:"quota_remaining"`
+	QuotaReset     time.Time `json:"quota_reset"`
+}
+
+// ServiceOverloadedResponse is the API response when global throttle is hit.
+// Per PRD-017 FR-6: 503 response for DDoS protection.
+type ServiceOverloadedResponse struct {
+	Error      string `json:"error"`   // "service_unavailable"
+	Message    string `json:"message"` // "Service is temporarily overloaded..."
+	RetryAfter int    `json:"retry_after"`
+}

--- a/internal/ratelimit/service/config.go
+++ b/internal/ratelimit/service/config.go
@@ -1,0 +1,121 @@
+package service
+
+import (
+	"time"
+
+	"credo/internal/ratelimit/models"
+)
+
+// Config holds rate limiting configuration.
+// Per PRD-017 TR-4: Rate limit configuration.
+type Config struct {
+	// Per-IP rate limits by endpoint class
+	// Per PRD-017 FR-1: IP rate limit tiers
+	IPLimits map[models.EndpointClass]Limit
+
+	// Per-user rate limits by endpoint class
+	// Per PRD-017 FR-2: User rate limit tiers
+	UserLimits map[models.EndpointClass]Limit
+
+	// Global limits for DDoS protection
+	// Per PRD-017 FR-6: Global throttling
+	Global GlobalLimit
+
+	// Auth-specific lockout configuration
+	// Per PRD-017 FR-2b: OWASP authentication protections
+	AuthLockout AuthLockoutConfig
+
+	// Partner quota tiers
+	// Per PRD-017 FR-5: API key quotas
+	QuotaTiers map[models.QuotaTier]QuotaLimit
+}
+
+// Limit defines rate limit parameters for an endpoint class.
+type Limit struct {
+	RequestsPerWindow int
+	Window            time.Duration
+}
+
+// GlobalLimit defines global throttling parameters.
+// Per PRD-017 FR-6: Per-instance and global limits.
+type GlobalLimit struct {
+	PerInstancePerSecond int // 1000 req/sec per instance
+	GlobalPerSecond      int // 10000 req/sec across all instances
+}
+
+// AuthLockoutConfig defines authentication lockout parameters.
+// Per PRD-017 FR-2b: OWASP authentication-specific throttling.
+type AuthLockoutConfig struct {
+	AttemptsPerWindow      int           // 5 attempts per 15 min
+	WindowDuration         time.Duration // 15 minutes
+	HardLockThreshold      int           // 10 failures/day triggers hard lock
+	HardLockDuration       time.Duration // 15 minutes
+	CaptchaAfterLockouts   int           // 3 consecutive lockouts require CAPTCHA
+	ProgressiveBackoffBase time.Duration // 250ms base delay
+}
+
+// QuotaLimit defines monthly quota parameters for a tier.
+type QuotaLimit struct {
+	MonthlyRequests int
+	OverageAllowed  bool
+	OverageRate     float64 // cost per request over limit
+}
+
+// DefaultConfig returns sensible defaults per PRD-017.
+func DefaultConfig() *Config {
+	return &Config{
+		// Per PRD-017 FR-1: IP rate limits
+		IPLimits: map[models.EndpointClass]Limit{
+			models.ClassAuth:      {RequestsPerWindow: 10, Window: time.Minute},
+			models.ClassSensitive: {RequestsPerWindow: 30, Window: time.Minute},
+			models.ClassRead:      {RequestsPerWindow: 100, Window: time.Minute},
+			models.ClassWrite:     {RequestsPerWindow: 50, Window: time.Minute},
+		},
+		// Per PRD-017 FR-2: User rate limits
+		UserLimits: map[models.EndpointClass]Limit{
+			models.ClassAuth:      {RequestsPerWindow: 50, Window: time.Hour},  // Consent operations
+			models.ClassSensitive: {RequestsPerWindow: 20, Window: time.Hour},  // VC issuance
+			models.ClassRead:      {RequestsPerWindow: 200, Window: time.Hour}, // Decision evaluations
+			models.ClassWrite:     {RequestsPerWindow: 100, Window: time.Hour}, // Registry lookups
+		},
+		// Per PRD-017 FR-6: Global limits
+		Global: GlobalLimit{
+			PerInstancePerSecond: 1000,
+			GlobalPerSecond:      10000,
+		},
+		// Per PRD-017 FR-2b: Auth lockout config
+		AuthLockout: AuthLockoutConfig{
+			AttemptsPerWindow:      5,
+			WindowDuration:         15 * time.Minute,
+			HardLockThreshold:      10,
+			HardLockDuration:       15 * time.Minute,
+			CaptchaAfterLockouts:   3,
+			ProgressiveBackoffBase: 250 * time.Millisecond,
+		},
+		// Per PRD-017 FR-5: Quota tiers
+		QuotaTiers: map[models.QuotaTier]QuotaLimit{
+			models.QuotaTierFree:       {MonthlyRequests: 1000, OverageAllowed: false},
+			models.QuotaTierStarter:    {MonthlyRequests: 10000, OverageAllowed: true, OverageRate: 0.01},
+			models.QuotaTierBusiness:   {MonthlyRequests: 100000, OverageAllowed: true, OverageRate: 0.005},
+			models.QuotaTierEnterprise: {MonthlyRequests: -1, OverageAllowed: true}, // unlimited
+		},
+	}
+}
+
+// GetIPLimit returns the IP rate limit for an endpoint class.
+func (c *Config) GetIPLimit(class models.EndpointClass) (int, time.Duration) {
+	if limit, ok := c.IPLimits[class]; ok {
+		return limit.RequestsPerWindow, limit.Window
+	}
+	// Default to read limits if class not found
+	return c.IPLimits[models.ClassRead].RequestsPerWindow, c.IPLimits[models.ClassRead].Window
+}
+
+// GetUserLimit returns the user rate limit for an endpoint class.
+func (c *Config) GetUserLimit(class models.EndpointClass) (int, time.Duration) {
+	if limit, ok := c.UserLimits[class]; ok {
+		return limit.RequestsPerWindow, limit.Window
+	}
+	// Default to read limits if class not found
+	return c.UserLimits[models.ClassRead].RequestsPerWindow, c.UserLimits[models.ClassRead].Window
+}

--- a/internal/ratelimit/service/interfaces.go
+++ b/internal/ratelimit/service/interfaces.go
@@ -1,0 +1,93 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"credo/internal/audit"
+	"credo/internal/ratelimit/models"
+)
+
+// BucketStore defines the persistence interface for rate limit buckets/counters.
+// Per PRD-017 TR-1: RateLimiter interface with Allow, AllowN, Reset operations.
+type BucketStore interface {
+	// Allow checks if a request is allowed and increments the counter.
+	// Returns the rate limit result with remaining tokens and reset time.
+	// Per PRD-017 TR-1: Allow(ctx, key, limit, window) -> (allowed, remaining, resetAt, err)
+	Allow(ctx context.Context, key string, limit int, window time.Duration) (*models.RateLimitResult, error)
+
+	// AllowN checks if a request with custom cost is allowed.
+	// Per PRD-017 TR-1: AllowN for operations that consume multiple tokens.
+	AllowN(ctx context.Context, key string, cost int, limit int, window time.Duration) (*models.RateLimitResult, error)
+
+	// Reset clears the rate limit counter for a key.
+	// Per PRD-017 TR-1: Admin operation to reset limits.
+	Reset(ctx context.Context, key string) error
+
+	// GetCurrentCount returns the current request count for a key.
+	// Used for monitoring and admin display.
+	GetCurrentCount(ctx context.Context, key string) (int, error)
+}
+
+// AllowlistStore defines the persistence interface for rate limit allowlist.
+// Per PRD-017 FR-4: Allowlist management for IPs and users.
+type AllowlistStore interface {
+	// Add adds an identifier to the allowlist.
+	Add(ctx context.Context, entry *models.AllowlistEntry) error
+
+	// Remove removes an identifier from the allowlist.
+	Remove(ctx context.Context, entryType models.AllowlistEntryType, identifier string) error
+
+	// IsAllowlisted checks if an identifier is in the allowlist and not expired.
+	// Per PRD-017 TR-1: IsAllowlisted(ctx, identifier) -> (bool, error)
+	IsAllowlisted(ctx context.Context, identifier string) (bool, error)
+
+	// List returns all active allowlist entries.
+	List(ctx context.Context) ([]*models.AllowlistEntry, error)
+}
+
+// AuthLockoutStore defines the persistence interface for authentication lockouts.
+// Per PRD-017 FR-2b: OWASP authentication-specific protections.
+type AuthLockoutStore interface {
+	// RecordFailure records a failed authentication attempt.
+	RecordFailure(ctx context.Context, identifier string) (*models.AuthLockout, error)
+
+	// GetLockout retrieves the current lockout state for an identifier.
+	GetLockout(ctx context.Context, identifier string) (*models.AuthLockout, error)
+
+	// ClearLockout clears the lockout state after successful authentication.
+	ClearLockout(ctx context.Context, identifier string) error
+
+	// IsLocked checks if an identifier is currently locked out.
+	IsLocked(ctx context.Context, identifier string) (bool, *time.Time, error)
+}
+
+// QuotaStore defines the persistence interface for partner API quotas.
+// Per PRD-017 FR-5: Partner API quota management.
+type QuotaStore interface {
+	// GetQuota retrieves the quota for an API key.
+	GetQuota(ctx context.Context, apiKeyID string) (*models.APIKeyQuota, error)
+
+	// IncrementUsage increments the usage counter for an API key.
+	IncrementUsage(ctx context.Context, apiKeyID string, count int) (*models.APIKeyQuota, error)
+
+	// SetQuota sets or updates the quota configuration for an API key.
+	SetQuota(ctx context.Context, quota *models.APIKeyQuota) error
+}
+
+// AuditPublisher defines the interface for publishing audit events.
+// Per PRD-017: Rate limit violations emit audit events.
+type AuditPublisher interface {
+	Emit(ctx context.Context, event audit.Event) error
+}
+
+// GlobalThrottleStore defines the interface for global request throttling.
+// Per PRD-017 FR-6: DDoS protection via global limits.
+type GlobalThrottleStore interface {
+	// IncrementGlobal increments the global request counter.
+	// Returns current count and whether limit is exceeded.
+	IncrementGlobal(ctx context.Context) (int, bool, error)
+
+	// GetGlobalCount returns the current global request count.
+	GetGlobalCount(ctx context.Context) (int, error)
+}

--- a/internal/ratelimit/service/service.go
+++ b/internal/ratelimit/service/service.go
@@ -1,0 +1,276 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"credo/internal/audit"
+	"credo/internal/platform/middleware"
+	"credo/internal/ratelimit/models"
+	dErrors "credo/pkg/domain-errors"
+)
+
+// Service provides rate limiting and abuse prevention operations.
+// Per PRD-017: Core rate limiting service.
+type Service struct {
+	buckets        BucketStore
+	allowlist      AllowlistStore
+	authLockout    AuthLockoutStore
+	quotas         QuotaStore
+	globalThrottle GlobalThrottleStore
+	auditPublisher AuditPublisher
+	logger         *slog.Logger
+	config         *Config
+}
+
+// Option is a functional option for configuring the Service.
+type Option func(*Service)
+
+// WithLogger sets the logger for the service.
+func WithLogger(logger *slog.Logger) Option {
+	return func(s *Service) {
+		s.logger = logger
+	}
+}
+
+// WithAuditPublisher sets the audit publisher for the service.
+func WithAuditPublisher(publisher AuditPublisher) Option {
+	return func(s *Service) {
+		s.auditPublisher = publisher
+	}
+}
+
+// WithConfig sets the rate limit configuration.
+func WithConfig(cfg *Config) Option {
+	return func(s *Service) {
+		s.config = cfg
+	}
+}
+
+// New creates a new rate limiting Service.
+func New(
+	buckets BucketStore,
+	allowlist AllowlistStore,
+	opts ...Option,
+) (*Service, error) {
+	if buckets == nil {
+		return nil, fmt.Errorf("buckets store is required")
+	}
+	if allowlist == nil {
+		return nil, fmt.Errorf("allowlist store is required")
+	}
+
+	svc := &Service{
+		buckets:   buckets,
+		allowlist: allowlist,
+		config:    DefaultConfig(),
+	}
+
+	for _, opt := range opts {
+		opt(svc)
+	}
+
+	return svc, nil
+}
+
+// SetAuthLockoutStore sets the auth lockout store (optional dependency).
+func (s *Service) SetAuthLockoutStore(store AuthLockoutStore) {
+	s.authLockout = store
+}
+
+// SetQuotaStore sets the quota store (optional dependency).
+func (s *Service) SetQuotaStore(store QuotaStore) {
+	s.quotas = store
+}
+
+// SetGlobalThrottleStore sets the global throttle store (optional dependency).
+func (s *Service) SetGlobalThrottleStore(store GlobalThrottleStore) {
+	s.globalThrottle = store
+}
+
+// CheckIPRateLimit checks the per-IP rate limit for an endpoint class.
+// Per PRD-017 FR-1: Per-IP rate limiting.
+//
+// TODO: Implement this method
+// 1. Check if IP is allowlisted - if so, return allowed with max limits
+// 2. Build rate limit key: "ip:{ip}:{class}"
+// 3. Get limit and window for endpoint class from config
+// 4. Call buckets.Allow() to check and increment
+// 5. If not allowed, emit audit event "rate_limit_exceeded"
+// 6. Return RateLimitResult with headers info
+func (s *Service) CheckIPRateLimit(ctx context.Context, ip string, class models.EndpointClass) (*models.RateLimitResult, error) {
+	// TODO: Implement - see steps above
+	return nil, dErrors.New(dErrors.CodeInternal, "not implemented")
+}
+
+// CheckUserRateLimit checks the per-user rate limit for an endpoint class.
+// Per PRD-017 FR-2: Per-user rate limiting.
+//
+// TODO: Implement this method
+// 1. Check if userID is allowlisted - if so, return allowed with max limits
+// 2. Build rate limit key: "user:{userID}:{class}"
+// 3. Get user limit and window for endpoint class from config
+// 4. Call buckets.Allow() to check and increment
+// 5. If not allowed, emit audit event "user_rate_limit_exceeded"
+// 6. Return RateLimitResult with quota info
+func (s *Service) CheckUserRateLimit(ctx context.Context, userID string, class models.EndpointClass) (*models.RateLimitResult, error) {
+	// TODO: Implement - see steps above
+	return nil, dErrors.New(dErrors.CodeInternal, "not implemented")
+}
+
+// CheckBothLimits checks both IP and user rate limits.
+// Per PRD-017 FR-2: Both must pass for authenticated endpoints.
+//
+// TODO: Implement this method
+// 1. Check IP rate limit
+// 2. If IP limit exceeded, return immediately
+// 3. Check user rate limit
+// 4. Return the more restrictive result
+func (s *Service) CheckBothLimits(ctx context.Context, ip, userID string, class models.EndpointClass) (*models.RateLimitResult, error) {
+	// TODO: Implement - see steps above
+	return nil, dErrors.New(dErrors.CodeInternal, "not implemented")
+}
+
+// CheckAuthRateLimit checks authentication-specific rate limits with lockout.
+// Per PRD-017 FR-2b: OWASP authentication-specific protections.
+//
+// TODO: Implement this method
+// 1. Build composite key: "{email/username}:{ip}"
+// 2. Check if currently locked out
+// 3. If locked, return 429 with lockout info
+// 4. Check standard IP rate limit for auth class
+// 5. Apply progressive backoff delay if approaching limit
+// 6. Return result with lockout state
+func (s *Service) CheckAuthRateLimit(ctx context.Context, identifier, ip string) (*models.RateLimitResult, error) {
+	// TODO: Implement - see steps above
+	return nil, dErrors.New(dErrors.CodeInternal, "not implemented")
+}
+
+// RecordAuthFailure records a failed authentication attempt.
+// Per PRD-017 FR-2b: Track failures for lockout.
+//
+// TODO: Implement this method
+// 1. Record failure in authLockout store
+// 2. Check if hard lock threshold reached (10 failures/day)
+// 3. If threshold reached, set locked_until
+// 4. Emit audit event "auth.lockout" if locked
+// 5. Check if CAPTCHA should be required
+func (s *Service) RecordAuthFailure(ctx context.Context, identifier, ip string) (*models.AuthLockout, error) {
+	// TODO: Implement - see steps above
+	return nil, dErrors.New(dErrors.CodeInternal, "not implemented")
+}
+
+// ClearAuthFailures clears auth failure state after successful login.
+// Per PRD-017 FR-2b: Clear state on success.
+//
+// TODO: Implement this method
+func (s *Service) ClearAuthFailures(ctx context.Context, identifier, ip string) error {
+	// TODO: Implement
+	return dErrors.New(dErrors.CodeInternal, "not implemented")
+}
+
+// GetProgressiveBackoff calculates backoff delay based on failure count.
+// Per PRD-017 FR-2b: Progressive backoff (250ms → 500ms → 1s).
+//
+// TODO: Implement this method
+// Returns delay duration based on failure count
+func (s *Service) GetProgressiveBackoff(failureCount int) time.Duration {
+	// TODO: Implement progressive backoff calculation
+	// Base: 250ms, doubles each failure, max 1s
+	return 0
+}
+
+// CheckAPIKeyQuota checks quota for partner API key.
+// Per PRD-017 FR-5: Partner API quotas.
+//
+// TODO: Implement this method
+// 1. Get quota for API key
+// 2. Check if under monthly limit
+// 3. If over limit and overage not allowed, return 429
+// 4. If over limit and overage allowed, record overage
+// 5. Increment usage counter
+// 6. Return quota info for headers
+func (s *Service) CheckAPIKeyQuota(ctx context.Context, apiKeyID string) (*models.APIKeyQuota, error) {
+	// TODO: Implement - see steps above
+	return nil, dErrors.New(dErrors.CodeInternal, "not implemented")
+}
+
+// CheckGlobalThrottle checks global request throttle for DDoS protection.
+// Per PRD-017 FR-6: Global throttling.
+//
+// TODO: Implement this method
+// 1. Increment global counter
+// 2. Check if exceeds per-instance limit
+// 3. Check if exceeds global limit (Redis-backed for distributed)
+// 4. If exceeded, return 503 response info
+func (s *Service) CheckGlobalThrottle(ctx context.Context) (bool, error) {
+	// TODO: Implement - see steps above
+	return true, nil // Allow by default until implemented
+}
+
+// AddToAllowlist adds an IP or user to the rate limit allowlist.
+// Per PRD-017 FR-4: Admin allowlist management.
+//
+// TODO: Implement this method
+// 1. Validate request
+// 2. Create AllowlistEntry domain object
+// 3. Save to allowlist store
+// 4. Emit audit event "rate_limit_allowlist_added"
+func (s *Service) AddToAllowlist(ctx context.Context, req *models.AddAllowlistRequest, adminUserID string) (*models.AllowlistEntry, error) {
+	// TODO: Implement - see steps above
+	return nil, dErrors.New(dErrors.CodeInternal, "not implemented")
+}
+
+// RemoveFromAllowlist removes an IP or user from the allowlist.
+// Per PRD-017 FR-4: Admin allowlist management.
+//
+// TODO: Implement this method
+// 1. Validate request
+// 2. Remove from allowlist store
+// 3. Emit audit event "rate_limit_allowlist_removed"
+func (s *Service) RemoveFromAllowlist(ctx context.Context, req *models.RemoveAllowlistRequest) error {
+	// TODO: Implement
+	return dErrors.New(dErrors.CodeInternal, "not implemented")
+}
+
+// ListAllowlist returns all active allowlist entries.
+// Per PRD-017 FR-4: Admin can view allowlist.
+//
+// TODO: Implement this method
+func (s *Service) ListAllowlist(ctx context.Context) ([]*models.AllowlistEntry, error) {
+	// TODO: Implement
+	return nil, dErrors.New(dErrors.CodeInternal, "not implemented")
+}
+
+// ResetRateLimit resets the rate limit counter for an identifier.
+// Per PRD-017 TR-1: Admin reset operation.
+//
+// TODO: Implement this method
+// 1. Validate request
+// 2. Build key(s) to reset
+// 3. Call buckets.Reset() for each key
+// 4. Emit audit event "rate_limit_reset"
+func (s *Service) ResetRateLimit(ctx context.Context, req *models.ResetRateLimitRequest) error {
+	// TODO: Implement
+	return dErrors.New(dErrors.CodeInternal, "not implemented")
+}
+
+// logAudit emits an audit event for rate limiting operations.
+func (s *Service) logAudit(ctx context.Context, event string, attrs ...any) {
+	if requestID := middleware.GetRequestID(ctx); requestID != "" {
+		attrs = append(attrs, "request_id", requestID)
+	}
+	args := append(attrs, "event", event, "log_type", "audit")
+	if s.logger != nil {
+		s.logger.InfoContext(ctx, event, args...)
+	}
+	if s.auditPublisher == nil {
+		return
+	}
+	// TODO: Extract user_id from attrs and emit audit event
+	_ = s.auditPublisher.Emit(ctx, audit.Event{
+		Action: event,
+	})
+}

--- a/internal/ratelimit/service/service_test.go
+++ b/internal/ratelimit/service/service_test.go
@@ -1,0 +1,318 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"credo/internal/ratelimit/models"
+)
+
+// MockBucketStore is a test double for BucketStore.
+type MockBucketStore struct {
+	AllowFunc           func(ctx context.Context, key string, limit int, window time.Duration) (*models.RateLimitResult, error)
+	AllowNFunc          func(ctx context.Context, key string, cost int, limit int, window time.Duration) (*models.RateLimitResult, error)
+	ResetFunc           func(ctx context.Context, key string) error
+	GetCurrentCountFunc func(ctx context.Context, key string) (int, error)
+}
+
+func (m *MockBucketStore) Allow(ctx context.Context, key string, limit int, window time.Duration) (*models.RateLimitResult, error) {
+	if m.AllowFunc != nil {
+		return m.AllowFunc(ctx, key, limit, window)
+	}
+	return &models.RateLimitResult{Allowed: true, Limit: limit, Remaining: limit - 1, ResetAt: time.Now().Add(window)}, nil
+}
+
+func (m *MockBucketStore) AllowN(ctx context.Context, key string, cost int, limit int, window time.Duration) (*models.RateLimitResult, error) {
+	if m.AllowNFunc != nil {
+		return m.AllowNFunc(ctx, key, cost, limit, window)
+	}
+	return &models.RateLimitResult{Allowed: true, Limit: limit, Remaining: limit - cost, ResetAt: time.Now().Add(window)}, nil
+}
+
+func (m *MockBucketStore) Reset(ctx context.Context, key string) error {
+	if m.ResetFunc != nil {
+		return m.ResetFunc(ctx, key)
+	}
+	return nil
+}
+
+func (m *MockBucketStore) GetCurrentCount(ctx context.Context, key string) (int, error) {
+	if m.GetCurrentCountFunc != nil {
+		return m.GetCurrentCountFunc(ctx, key)
+	}
+	return 0, nil
+}
+
+// MockAllowlistStore is a test double for AllowlistStore.
+type MockAllowlistStore struct {
+	AddFunc           func(ctx context.Context, entry *models.AllowlistEntry) error
+	RemoveFunc        func(ctx context.Context, entryType models.AllowlistEntryType, identifier string) error
+	IsAllowlistedFunc func(ctx context.Context, identifier string) (bool, error)
+	ListFunc          func(ctx context.Context) ([]*models.AllowlistEntry, error)
+}
+
+func (m *MockAllowlistStore) Add(ctx context.Context, entry *models.AllowlistEntry) error {
+	if m.AddFunc != nil {
+		return m.AddFunc(ctx, entry)
+	}
+	return nil
+}
+
+func (m *MockAllowlistStore) Remove(ctx context.Context, entryType models.AllowlistEntryType, identifier string) error {
+	if m.RemoveFunc != nil {
+		return m.RemoveFunc(ctx, entryType, identifier)
+	}
+	return nil
+}
+
+func (m *MockAllowlistStore) IsAllowlisted(ctx context.Context, identifier string) (bool, error) {
+	if m.IsAllowlistedFunc != nil {
+		return m.IsAllowlistedFunc(ctx, identifier)
+	}
+	return false, nil
+}
+
+func (m *MockAllowlistStore) List(ctx context.Context) ([]*models.AllowlistEntry, error) {
+	if m.ListFunc != nil {
+		return m.ListFunc(ctx)
+	}
+	return nil, nil
+}
+
+// TestService_CheckIPRateLimit tests per-IP rate limiting.
+// Per PRD-017 FR-1: Per-IP rate limiting.
+func TestService_CheckIPRateLimit(t *testing.T) {
+	t.Skip("TODO: Implement test after CheckIPRateLimit is implemented")
+
+	buckets := &MockBucketStore{}
+	allowlist := &MockAllowlistStore{}
+	svc, err := New(buckets, allowlist)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// TODO: Test cases to implement:
+	// 1. Request allowed when under limit
+	// 2. Request denied when at/over limit
+	// 3. Allowlisted IP bypasses limits
+	// 4. Correct endpoint class limits applied
+
+	t.Run("request allowed under limit", func(t *testing.T) {
+		buckets.AllowFunc = func(ctx context.Context, key string, limit int, window time.Duration) (*models.RateLimitResult, error) {
+			return &models.RateLimitResult{Allowed: true, Limit: 10, Remaining: 9}, nil
+		}
+
+		result, err := svc.CheckIPRateLimit(ctx, "192.168.1.1", models.ClassAuth)
+		require.NoError(t, err)
+		assert.True(t, result.Allowed)
+		assert.Equal(t, 9, result.Remaining)
+	})
+
+	t.Run("request denied at limit", func(t *testing.T) {
+		// TODO: Implement
+	})
+
+	t.Run("allowlisted IP bypasses limit", func(t *testing.T) {
+		// TODO: Implement
+	})
+}
+
+// TestService_CheckUserRateLimit tests per-user rate limiting.
+// Per PRD-017 FR-2: Per-user rate limiting.
+func TestService_CheckUserRateLimit(t *testing.T) {
+	t.Skip("TODO: Implement test after CheckUserRateLimit is implemented")
+
+	buckets := &MockBucketStore{}
+	allowlist := &MockAllowlistStore{}
+	svc, err := New(buckets, allowlist)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// TODO: Test cases to implement:
+	// 1. User request allowed under limit
+	// 2. User request denied at limit
+	// 3. Different limits for different endpoint classes
+
+	t.Run("user request allowed under limit", func(t *testing.T) {
+		// TODO: Implement
+		_ = svc
+		_ = ctx
+	})
+}
+
+// TestService_CheckBothLimits tests combined IP and user rate limiting.
+// Per PRD-017 FR-2: Both must pass for authenticated endpoints.
+func TestService_CheckBothLimits(t *testing.T) {
+	t.Skip("TODO: Implement test after CheckBothLimits is implemented")
+
+	buckets := &MockBucketStore{}
+	allowlist := &MockAllowlistStore{}
+	svc, err := New(buckets, allowlist)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// TODO: Test cases to implement:
+	// 1. Both limits pass → allowed
+	// 2. IP limit fails, user limit passes → denied
+	// 3. IP limit passes, user limit fails → denied
+	// 4. Both limits fail → denied
+
+	t.Run("both limits pass", func(t *testing.T) {
+		// TODO: Implement
+		_ = svc
+		_ = ctx
+	})
+
+	t.Run("IP limit fails user limit passes", func(t *testing.T) {
+		// TODO: Implement
+	})
+}
+
+// TestService_CheckAuthRateLimit tests auth-specific rate limiting with lockout.
+// Per PRD-017 FR-2b: OWASP authentication protections.
+func TestService_CheckAuthRateLimit(t *testing.T) {
+	t.Skip("TODO: Implement test after CheckAuthRateLimit is implemented")
+
+	buckets := &MockBucketStore{}
+	allowlist := &MockAllowlistStore{}
+	svc, err := New(buckets, allowlist)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// TODO: Test cases to implement:
+	// 1. Request allowed when not locked
+	// 2. Request denied when locked
+	// 3. Composite key includes email and IP
+
+	t.Run("request allowed when not locked", func(t *testing.T) {
+		// TODO: Implement
+		_ = svc
+		_ = ctx
+	})
+}
+
+// TestService_RecordAuthFailure tests auth failure recording.
+// Per PRD-017 FR-2b: Track failures for lockout.
+func TestService_RecordAuthFailure(t *testing.T) {
+	t.Skip("TODO: Implement test after RecordAuthFailure is implemented")
+
+	buckets := &MockBucketStore{}
+	allowlist := &MockAllowlistStore{}
+	svc, err := New(buckets, allowlist)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// TODO: Test cases to implement:
+	// 1. Failure count incremented
+	// 2. Lockout triggered at threshold
+	// 3. Hard lock after daily threshold
+
+	t.Run("failure count incremented", func(t *testing.T) {
+		// TODO: Implement
+		_ = svc
+		_ = ctx
+	})
+}
+
+// TestService_GetProgressiveBackoff tests backoff calculation.
+// Per PRD-017 FR-2b: Progressive backoff (250ms → 500ms → 1s).
+func TestService_GetProgressiveBackoff(t *testing.T) {
+	t.Skip("TODO: Implement test after GetProgressiveBackoff is implemented")
+
+	buckets := &MockBucketStore{}
+	allowlist := &MockAllowlistStore{}
+	svc, err := New(buckets, allowlist)
+	require.NoError(t, err)
+
+	// TODO: Test cases to implement:
+	// 1. First failure: 250ms
+	// 2. Second failure: 500ms
+	// 3. Third+ failure: 1s (capped)
+
+	t.Run("progressive backoff values", func(t *testing.T) {
+		delay1 := svc.GetProgressiveBackoff(1)
+		assert.Equal(t, 250*time.Millisecond, delay1)
+
+		delay2 := svc.GetProgressiveBackoff(2)
+		assert.Equal(t, 500*time.Millisecond, delay2)
+
+		delay3 := svc.GetProgressiveBackoff(3)
+		assert.Equal(t, time.Second, delay3)
+	})
+}
+
+// TestService_AddToAllowlist tests allowlist addition.
+// Per PRD-017 FR-4: Admin allowlist management.
+func TestService_AddToAllowlist(t *testing.T) {
+	t.Skip("TODO: Implement test after AddToAllowlist is implemented")
+
+	buckets := &MockBucketStore{}
+	allowlist := &MockAllowlistStore{}
+	svc, err := New(buckets, allowlist)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// TODO: Test cases to implement:
+	// 1. IP added successfully
+	// 2. User ID added successfully
+	// 3. Entry with expiration
+
+	t.Run("add IP to allowlist", func(t *testing.T) {
+		// TODO: Implement
+		_ = svc
+		_ = ctx
+	})
+}
+
+// TestService_ResetRateLimit tests admin reset operation.
+// Per PRD-017 TR-1: Admin reset operation.
+func TestService_ResetRateLimit(t *testing.T) {
+	t.Skip("TODO: Implement test after ResetRateLimit is implemented")
+
+	buckets := &MockBucketStore{}
+	allowlist := &MockAllowlistStore{}
+	svc, err := New(buckets, allowlist)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// TODO: Test cases to implement:
+	// 1. Reset clears rate limit for identifier
+	// 2. Reset specific class only
+	// 3. Reset all classes for identifier
+
+	t.Run("reset clears rate limit", func(t *testing.T) {
+		// TODO: Implement
+		_ = svc
+		_ = ctx
+	})
+}
+
+// TestConfig_Defaults tests default configuration.
+func TestConfig_Defaults(t *testing.T) {
+	cfg := DefaultConfig()
+
+	// Per PRD-017 FR-1: IP rate limits
+	authLimit, authWindow := cfg.GetIPLimit(models.ClassAuth)
+	assert.Equal(t, 10, authLimit)
+	assert.Equal(t, time.Minute, authWindow)
+
+	sensitiveLimit, _ := cfg.GetIPLimit(models.ClassSensitive)
+	assert.Equal(t, 30, sensitiveLimit)
+
+	readLimit, _ := cfg.GetIPLimit(models.ClassRead)
+	assert.Equal(t, 100, readLimit)
+
+	// Per PRD-017 FR-6: Global limits
+	assert.Equal(t, 1000, cfg.Global.PerInstancePerSecond)
+	assert.Equal(t, 10000, cfg.Global.GlobalPerSecond)
+}

--- a/internal/ratelimit/store/allowlist/store_memory.go
+++ b/internal/ratelimit/store/allowlist/store_memory.go
@@ -1,0 +1,82 @@
+package allowlist
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"credo/internal/ratelimit/models"
+	dErrors "credo/pkg/domain-errors"
+)
+
+// InMemoryAllowlistStore implements AllowlistStore using in-memory storage.
+// Per PRD-017 FR-4: Allowlist bypass for rate limits.
+type InMemoryAllowlistStore struct {
+	mu      sync.RWMutex
+	entries map[string]*models.AllowlistEntry // keyed by "{type}:{identifier}"
+}
+
+// NewInMemoryAllowlistStore creates a new in-memory allowlist store.
+func NewInMemoryAllowlistStore() *InMemoryAllowlistStore {
+	return &InMemoryAllowlistStore{
+		entries: make(map[string]*models.AllowlistEntry),
+	}
+}
+
+// Add adds an identifier to the allowlist.
+// Per PRD-017 FR-4: Add to Redis set with optional TTL.
+//
+// TODO: Implement this method
+// 1. Build key: "{type}:{identifier}"
+// 2. Check if entry already exists
+// 3. Store entry
+func (s *InMemoryAllowlistStore) Add(ctx context.Context, entry *models.AllowlistEntry) error {
+	// TODO: Implement
+	return dErrors.New(dErrors.CodeInternal, "not implemented")
+}
+
+// Remove removes an identifier from the allowlist.
+// Per PRD-017 FR-4: Remove from allowlist.
+//
+// TODO: Implement this method
+func (s *InMemoryAllowlistStore) Remove(ctx context.Context, entryType models.AllowlistEntryType, identifier string) error {
+	// TODO: Implement
+	return dErrors.New(dErrors.CodeInternal, "not implemented")
+}
+
+// IsAllowlisted checks if an identifier is in the allowlist and not expired.
+// Per PRD-017 TR-1, FR-4: Check allowlist before rate limiting.
+//
+// TODO: Implement this method
+// 1. Check both "ip:{identifier}" and "user_id:{identifier}" keys
+// 2. If found, check expiration
+// 3. If expired, optionally clean up
+// 4. Return true if found and not expired
+func (s *InMemoryAllowlistStore) IsAllowlisted(ctx context.Context, identifier string) (bool, error) {
+	// TODO: Implement
+	return false, nil // Default to not allowlisted
+}
+
+// List returns all active (non-expired) allowlist entries.
+//
+// TODO: Implement this method
+// 1. Iterate all entries
+// 2. Filter out expired entries
+// 3. Return list
+func (s *InMemoryAllowlistStore) List(ctx context.Context) ([]*models.AllowlistEntry, error) {
+	// TODO: Implement
+	return nil, dErrors.New(dErrors.CodeInternal, "not implemented")
+}
+
+// buildKey creates the map key for an allowlist entry.
+func buildKey(entryType models.AllowlistEntryType, identifier string) string {
+	return string(entryType) + ":" + identifier
+}
+
+// isExpired checks if an entry has expired.
+func isExpired(entry *models.AllowlistEntry) bool {
+	if entry.ExpiresAt == nil {
+		return false
+	}
+	return time.Now().After(*entry.ExpiresAt)
+}

--- a/internal/ratelimit/store/allowlist/store_memory_test.go
+++ b/internal/ratelimit/store/allowlist/store_memory_test.go
@@ -1,0 +1,135 @@
+package allowlist
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"credo/internal/ratelimit/models"
+)
+
+// TestInMemoryAllowlistStore_Add tests adding entries to the allowlist.
+// Per PRD-017 FR-4: Allowlist management.
+func TestInMemoryAllowlistStore_Add(t *testing.T) {
+	t.Skip("TODO: Implement test after Add is implemented")
+
+	store := NewInMemoryAllowlistStore()
+	ctx := context.Background()
+
+	// TODO: Test cases to implement:
+	// 1. Add IP entry successfully
+	// 2. Add user_id entry successfully
+	// 3. Add entry with expiration
+	// 4. Duplicate entry handling
+
+	t.Run("add IP entry", func(t *testing.T) {
+		entry := &models.AllowlistEntry{
+			ID:         "test-1",
+			Type:       models.AllowlistTypeIP,
+			Identifier: "192.168.1.100",
+			Reason:     "Internal monitoring",
+			CreatedAt:  time.Now(),
+			CreatedBy:  "admin-user-id",
+		}
+		err := store.Add(ctx, entry)
+		require.NoError(t, err)
+	})
+
+	t.Run("add user_id entry", func(t *testing.T) {
+		// TODO: Implement
+	})
+
+	t.Run("add entry with expiration", func(t *testing.T) {
+		// TODO: Implement
+	})
+}
+
+// TestInMemoryAllowlistStore_Remove tests removing entries from the allowlist.
+func TestInMemoryAllowlistStore_Remove(t *testing.T) {
+	t.Skip("TODO: Implement test after Remove is implemented")
+
+	store := NewInMemoryAllowlistStore()
+	ctx := context.Background()
+
+	// TODO: Test cases to implement:
+	// 1. Remove existing entry
+	// 2. Remove non-existent entry (should not error)
+
+	t.Run("remove existing entry", func(t *testing.T) {
+		// TODO: Implement
+		_ = store
+		_ = ctx
+	})
+
+	t.Run("remove non-existent entry", func(t *testing.T) {
+		// TODO: Implement
+	})
+}
+
+// TestInMemoryAllowlistStore_IsAllowlisted tests checking allowlist status.
+// Per PRD-017 FR-4: Middleware check before rate limiting.
+func TestInMemoryAllowlistStore_IsAllowlisted(t *testing.T) {
+	t.Skip("TODO: Implement test after IsAllowlisted is implemented")
+
+	store := NewInMemoryAllowlistStore()
+	ctx := context.Background()
+
+	// TODO: Test cases to implement:
+	// 1. Non-existent identifier returns false
+	// 2. Existing IP entry returns true
+	// 3. Existing user_id entry returns true
+	// 4. Expired entry returns false
+	// 5. Entry with no expiration returns true
+
+	t.Run("non-existent identifier returns false", func(t *testing.T) {
+		allowed, err := store.IsAllowlisted(ctx, "unknown-ip")
+		require.NoError(t, err)
+		assert.False(t, allowed)
+	})
+
+	t.Run("existing IP entry returns true", func(t *testing.T) {
+		// TODO: Implement - first add an entry, then check
+	})
+
+	t.Run("expired entry returns false", func(t *testing.T) {
+		// TODO: Implement - add entry with past expiration
+	})
+}
+
+// TestInMemoryAllowlistStore_List tests listing allowlist entries.
+func TestInMemoryAllowlistStore_List(t *testing.T) {
+	t.Skip("TODO: Implement test after List is implemented")
+
+	store := NewInMemoryAllowlistStore()
+	ctx := context.Background()
+
+	// TODO: Test cases to implement:
+	// 1. Empty store returns empty list
+	// 2. Returns all non-expired entries
+	// 3. Excludes expired entries
+
+	t.Run("empty store returns empty list", func(t *testing.T) {
+		entries, err := store.List(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, entries)
+	})
+
+	t.Run("returns non-expired entries", func(t *testing.T) {
+		// TODO: Implement
+	})
+}
+
+// TestInMemoryAllowlistStore_Concurrent tests concurrent access.
+func TestInMemoryAllowlistStore_Concurrent(t *testing.T) {
+	t.Skip("TODO: Implement test after methods are implemented")
+
+	store := NewInMemoryAllowlistStore()
+	ctx := context.Background()
+
+	// TODO: Test concurrent Add, Remove, and IsAllowlisted operations
+	_ = store
+	_ = ctx
+}

--- a/internal/ratelimit/store/bucket/store_memory.go
+++ b/internal/ratelimit/store/bucket/store_memory.go
@@ -1,0 +1,82 @@
+package bucket
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"credo/internal/ratelimit/models"
+	dErrors "credo/pkg/domain-errors"
+)
+
+// InMemoryBucketStore implements BucketStore using in-memory sliding window.
+// Per PRD-017 TR-1: In-memory implementation (MVP, not distributed).
+// For production, use RedisStore instead.
+type InMemoryBucketStore struct {
+	mu      sync.RWMutex
+	buckets map[string]*slidingWindow
+}
+
+// slidingWindow tracks request timestamps for sliding window rate limiting.
+// Per PRD-017 FR-3: Sliding window algorithm prevents boundary attacks.
+type slidingWindow struct {
+	timestamps []time.Time
+	window     time.Duration
+}
+
+// NewInMemoryBucketStore creates a new in-memory bucket store.
+func NewInMemoryBucketStore() *InMemoryBucketStore {
+	return &InMemoryBucketStore{
+		buckets: make(map[string]*slidingWindow),
+	}
+}
+
+// Allow checks if a request is allowed and increments the counter.
+// Per PRD-017 TR-1, FR-3: Sliding window algorithm.
+//
+// TODO: Implement this method
+// 1. Lock the mutex
+// 2. Get or create sliding window for key
+// 3. Remove timestamps older than (now - window)
+// 4. Count remaining timestamps
+// 5. If count >= limit, return not allowed with remaining=0
+// 6. Add current timestamp
+// 7. Calculate reset time (oldest timestamp + window, or now + window if empty)
+// 8. Return RateLimitResult
+func (s *InMemoryBucketStore) Allow(ctx context.Context, key string, limit int, window time.Duration) (*models.RateLimitResult, error) {
+	// TODO: Implement - see steps above
+	return nil, dErrors.New(dErrors.CodeInternal, "not implemented")
+}
+
+// AllowN checks if a request with custom cost is allowed.
+// Per PRD-017 TR-1: AllowN for operations that consume multiple tokens.
+//
+// TODO: Implement this method
+// Similar to Allow but adds 'cost' number of timestamps instead of 1
+func (s *InMemoryBucketStore) AllowN(ctx context.Context, key string, cost int, limit int, window time.Duration) (*models.RateLimitResult, error) {
+	// TODO: Implement
+	return nil, dErrors.New(dErrors.CodeInternal, "not implemented")
+}
+
+// Reset clears the rate limit counter for a key.
+// Per PRD-017 TR-1: Admin reset operation.
+//
+// TODO: Implement this method
+func (s *InMemoryBucketStore) Reset(ctx context.Context, key string) error {
+	// TODO: Implement
+	return dErrors.New(dErrors.CodeInternal, "not implemented")
+}
+
+// GetCurrentCount returns the current request count for a key.
+//
+// TODO: Implement this method
+func (s *InMemoryBucketStore) GetCurrentCount(ctx context.Context, key string) (int, error) {
+	// TODO: Implement
+	return 0, dErrors.New(dErrors.CodeInternal, "not implemented")
+}
+
+// cleanup removes expired timestamps from a sliding window.
+// Helper method for internal use.
+func (sw *slidingWindow) cleanup(now time.Time) {
+	// TODO: Implement - remove timestamps older than (now - sw.window)
+}

--- a/internal/ratelimit/store/bucket/store_memory_test.go
+++ b/internal/ratelimit/store/bucket/store_memory_test.go
@@ -1,0 +1,133 @@
+package bucket
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInMemoryBucketStore_Allow tests the basic Allow functionality.
+// Per PRD-017 FR-1, FR-3: Sliding window rate limiting.
+func TestInMemoryBucketStore_Allow(t *testing.T) {
+	t.Skip("TODO: Implement test after Allow is implemented")
+
+	store := NewInMemoryBucketStore()
+	ctx := context.Background()
+
+	// TODO: Test cases to implement:
+	// 1. First request should be allowed
+	// 2. Requests up to limit should be allowed
+	// 3. Request at limit should be denied
+	// 4. After window expires, requests should be allowed again
+
+	t.Run("first request allowed", func(t *testing.T) {
+		result, err := store.Allow(ctx, "test:key:1", 10, time.Minute)
+		require.NoError(t, err)
+		assert.True(t, result.Allowed)
+		assert.Equal(t, 10, result.Limit)
+		assert.Equal(t, 9, result.Remaining)
+	})
+
+	t.Run("requests up to limit allowed", func(t *testing.T) {
+		// TODO: Implement - make 9 more requests, all should be allowed
+	})
+
+	t.Run("request over limit denied", func(t *testing.T) {
+		// TODO: Implement - 11th request should be denied
+	})
+
+	t.Run("after window expires requests allowed", func(t *testing.T) {
+		// TODO: Implement - wait for window to expire, then request should be allowed
+	})
+}
+
+// TestInMemoryBucketStore_AllowN tests the AllowN functionality with custom cost.
+// Per PRD-017 TR-1: AllowN for operations consuming multiple tokens.
+func TestInMemoryBucketStore_AllowN(t *testing.T) {
+	t.Skip("TODO: Implement test after AllowN is implemented")
+
+	store := NewInMemoryBucketStore()
+	ctx := context.Background()
+
+	// TODO: Test cases to implement:
+	// 1. Request with cost 1 behaves like Allow
+	// 2. Request with cost 5 consumes 5 tokens
+	// 3. Request with cost > remaining should be denied
+
+	t.Run("cost of 1 behaves like Allow", func(t *testing.T) {
+		// TODO: Implement
+	})
+
+	t.Run("cost of 5 consumes 5 tokens", func(t *testing.T) {
+		// TODO: Implement
+	})
+
+	t.Run("cost greater than remaining denied", func(t *testing.T) {
+		// TODO: Implement
+	})
+}
+
+// TestInMemoryBucketStore_Reset tests the Reset functionality.
+// Per PRD-017 TR-1: Admin reset operation.
+func TestInMemoryBucketStore_Reset(t *testing.T) {
+	t.Skip("TODO: Implement test after Reset is implemented")
+
+	store := NewInMemoryBucketStore()
+	ctx := context.Background()
+
+	// TODO: Test cases to implement:
+	// 1. Reset clears counter for key
+	// 2. Reset on non-existent key is no-op
+	// 3. After reset, full limit is available
+
+	t.Run("reset clears counter", func(t *testing.T) {
+		// TODO: Implement
+	})
+
+	t.Run("reset non-existent key is no-op", func(t *testing.T) {
+		// TODO: Implement
+	})
+}
+
+// TestInMemoryBucketStore_SlidingWindow tests sliding window behavior.
+// Per PRD-017 FR-3: Sliding window prevents boundary attacks.
+func TestInMemoryBucketStore_SlidingWindow(t *testing.T) {
+	t.Skip("TODO: Implement test after Allow is implemented")
+
+	store := NewInMemoryBucketStore()
+	ctx := context.Background()
+
+	// TODO: Test cases to implement:
+	// 1. Timestamps outside window are cleaned up
+	// 2. Boundary attack prevented (requests at window boundary)
+	// 3. Smooth rate distribution over time
+
+	t.Run("old timestamps cleaned up", func(t *testing.T) {
+		// TODO: Implement
+	})
+
+	t.Run("boundary attack prevented", func(t *testing.T) {
+		// TODO: Implement - spike at window edge should not allow double limit
+	})
+}
+
+// TestInMemoryBucketStore_Concurrent tests concurrent access.
+func TestInMemoryBucketStore_Concurrent(t *testing.T) {
+	t.Skip("TODO: Implement test after Allow is implemented")
+
+	store := NewInMemoryBucketStore()
+	ctx := context.Background()
+
+	// TODO: Test cases to implement:
+	// 1. Concurrent requests are handled safely
+	// 2. Total allowed does not exceed limit under concurrency
+
+	t.Run("concurrent requests safe", func(t *testing.T) {
+		// TODO: Implement - use goroutines to make concurrent requests
+		_ = store
+		_ = ctx
+	})
+}


### PR DESCRIPTION
Add scaffolding for rate limiting and abuse prevention per PRD-017:

Module structure:
- internal/ratelimit/models: Domain models, requests, responses
- internal/ratelimit/service: Interfaces, config, service stubs
- internal/ratelimit/store: In-memory bucket and allowlist stubs
- internal/ratelimit/handler: Admin endpoint stubs
- internal/ratelimit/middleware: Rate limit middleware stubs
- e2e/features/ratelimit.feature: Gherkin scenarios for all requirements

Key features stubbed:
- FR-1: Per-IP rate limiting with endpoint classes
- FR-2: Per-user rate limiting for authenticated endpoints
- FR-2b: OWASP auth-specific protections (lockout, backoff)
- FR-3: Sliding window algorithm
- FR-4: Admin allowlist bypass
- FR-5: Partner API quotas
- FR-6: Global DDoS throttling

All methods contain TODO comments for implementation.
Tests are stubbed with t.Skip() awaiting implementation.