### PR TITLE
Unify demo pages and clean up admin navigation

### DIFF
--- a/frontend/public/admin.html
+++ b/frontend/public/admin.html
@@ -28,67 +28,84 @@
     <nav class="bg-white shadow-sm border-b border-gray-200">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between items-center h-16">
-          <div class="flex items-center space-x-4">
-            <h1 class="text-xl font-bold text-gray-900">
-              Credo - Admin Dashboard
-            </h1>
+          <!-- Left: Logo & Title -->
+          <div class="flex items-center space-x-3">
+            <a href="hub.html" class="flex items-center space-x-3">
+              <img src="/img/credo-logo.svg" alt="Credo" class="h-9 w-9" />
+              <span class="text-xl font-bold text-gray-900">Credo</span>
+            </a>
+            <span class="text-gray-300">|</span>
+            <span class="text-lg font-medium text-gray-700">Admin Dashboard</span>
             <span
               class="px-2 py-1 text-xs font-semibold rounded bg-purple-100 text-purple-800"
             >
-              ADMIN VIEW
-            </span>
-            <span
-              class="px-2 py-1 text-xs font-semibold rounded regulated-indicator"
-              :class="regulatedMode ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'"
-            >
-              <span
-                x-text="regulatedMode ? '🔒 REGULATED MODE' : 'STANDARD MODE'"
-              ></span>
+              ADMIN
             </span>
           </div>
+
+          <!-- Right: Actions & Navigation -->
           <div class="flex items-center space-x-4">
-            <button
-              @click="showTokenInput = true"
-              class="text-sm px-3 py-1 rounded border border-purple-600 text-purple-600"
-              title="Change admin token"
-            >
-              🔑 Token
-            </button>
-            <button
-              @click="clearAdminToken"
-              class="text-sm px-3 py-1 rounded border border-red-600 text-red-600"
-              title="Clear token and logout"
-            >
-              Logout
-            </button>
-            <button
-              @click="refreshData"
-              :disabled="loading"
-              class="text-sm px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
-            >
-              <span x-show="!loading">🔄 Refresh</span>
-              <span x-show="loading">Loading...</span>
-            </button>
+            <!-- Admin Actions -->
+            <div class="flex items-center space-x-2 pr-4 border-r border-gray-200">
+              <span
+                class="px-2 py-1 text-xs font-semibold rounded"
+                :class="regulatedMode ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'"
+              >
+                <span
+                  x-text="regulatedMode ? '🔒 Regulated' : 'Standard'"
+                ></span>
+              </span>
+              <button
+                @click="showTokenInput = true"
+                class="text-sm px-2 py-1 rounded border border-gray-300 text-gray-600 hover:border-purple-400 hover:text-purple-600"
+                title="Change admin token"
+              >
+                🔑
+              </button>
+              <button
+                @click="refreshData"
+                :disabled="loading"
+                class="text-sm px-2 py-1 rounded border border-gray-300 text-gray-600 hover:border-blue-400 hover:text-blue-600 disabled:opacity-50"
+                title="Refresh data"
+              >
+                <span x-show="!loading">🔄</span>
+                <span x-show="loading">...</span>
+              </button>
+              <button
+                @click="clearAdminToken"
+                class="text-sm px-2 py-1 rounded border border-gray-300 text-gray-600 hover:border-red-400 hover:text-red-600"
+                title="Logout"
+              >
+                🚪
+              </button>
+            </div>
+
+            <!-- Navigation Links -->
             <a
-              href="demo.html"
-              class="text-sm text-blue-600 hover:text-blue-800 font-medium"
-              >OAuth Demo</a
-            >
-            <a
-              href="consent-demo.html"
-              class="text-sm text-green-600 hover:text-green-800 font-medium"
-              >Consent Demo</a
-            >
-            <a
-              href="attacks.html"
-              class="text-sm text-red-600 hover:text-red-900 font-semibold"
-              >⚠️ Attack Paths</a
+              href="hub.html"
+              class="text-sm text-gray-600 hover:text-gray-900"
+              >Demo Hub</a
             >
             <a
               href="index.html"
               class="text-sm text-gray-600 hover:text-gray-900"
-              >User View</a
+              >User Portal</a
             >
+            <a
+              href="https://github.com/abramin/Credo"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-gray-500 hover:text-gray-700"
+              title="View on GitHub"
+            >
+              <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
+                <path
+                  fill-rule="evenodd"
+                  d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+            </a>
           </div>
         </div>
       </div>

--- a/frontend/public/attacks.html
+++ b/frontend/public/attacks.html
@@ -32,19 +32,28 @@
     <nav class="bg-white shadow-sm border-b border-gray-200">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between items-center h-16">
-          <div class="flex items-center">
-            <h1 class="text-xl font-bold text-gray-900">OAuth2 Attack Paths</h1>
+          <!-- Left: Logo & Title -->
+          <div class="flex items-center space-x-3">
+            <a href="hub.html" class="flex items-center space-x-3">
+              <img src="/img/credo-logo.svg" alt="Credo" class="h-9 w-9" />
+              <span class="text-xl font-bold text-gray-900">Credo</span>
+            </a>
+            <span class="text-gray-300">|</span>
+            <span class="text-lg font-medium text-gray-700">OAuth2 Attack Paths</span>
+            <span class="px-2 py-1 text-xs font-semibold rounded bg-red-100 text-red-700">Security</span>
           </div>
+
+          <!-- Right: Navigation -->
           <div class="flex items-center space-x-4">
             <a
-              href="demo.html"
-              class="text-sm text-gray-600 hover:text-gray-900"
-              >OAuth Demo</a
+              href="hub.html"
+              class="text-sm text-red-600 hover:text-red-800 font-medium"
+              >← Demo Hub</a
             >
             <a
-              href="consent-demo.html"
-              class="text-sm text-green-600 hover:text-green-800 font-medium"
-              >Consent Demo</a
+              href="admin.html"
+              class="text-sm text-gray-600 hover:text-gray-900"
+              >Admin</a
             >
             <a
               href="index.html"
@@ -52,10 +61,20 @@
               >User Portal</a
             >
             <a
-              href="admin.html"
-              class="text-sm text-gray-600 hover:text-gray-900"
-              >Admin View</a
+              href="https://github.com/abramin/Credo"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-gray-500 hover:text-gray-700"
+              title="View on GitHub"
             >
+              <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
+                <path
+                  fill-rule="evenodd"
+                  d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+            </a>
           </div>
         </div>
       </div>

--- a/frontend/public/consent-demo.html
+++ b/frontend/public/consent-demo.html
@@ -21,21 +21,28 @@
     <nav class="bg-white shadow-sm border-b border-gray-200">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between items-center h-16">
-          <div class="flex items-center">
-            <h1 class="text-xl font-bold text-gray-900">
-              Consent Management Demo
-            </h1>
+          <!-- Left: Logo & Title -->
+          <div class="flex items-center space-x-3">
+            <a href="hub.html" class="flex items-center space-x-3">
+              <img src="/img/credo-logo.svg" alt="Credo" class="h-9 w-9" />
+              <span class="text-xl font-bold text-gray-900">Credo</span>
+            </a>
+            <span class="text-gray-300">|</span>
+            <span class="text-lg font-medium text-gray-700">Consent Management Demo</span>
+            <span class="px-2 py-1 text-xs font-semibold rounded bg-green-100 text-green-700">PRD-002</span>
           </div>
+
+          <!-- Right: Navigation -->
           <div class="flex items-center space-x-4">
             <a
-              href="demo.html"
-              class="text-sm text-gray-600 hover:text-gray-900"
-              >OAuth Demo</a
+              href="hub.html"
+              class="text-sm text-green-600 hover:text-green-800 font-medium"
+              >← Demo Hub</a
             >
             <a
-              href="attacks.html"
-              class="text-sm text-red-600 hover:text-red-900 font-semibold"
-              >⚠️ Attack Paths</a
+              href="admin.html"
+              class="text-sm text-gray-600 hover:text-gray-900"
+              >Admin</a
             >
             <a
               href="index.html"
@@ -43,10 +50,20 @@
               >User Portal</a
             >
             <a
-              href="admin.html"
-              class="text-sm text-gray-600 hover:text-gray-900"
-              >Admin View</a
+              href="https://github.com/abramin/Credo"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-gray-500 hover:text-gray-700"
+              title="View on GitHub"
             >
+              <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
+                <path
+                  fill-rule="evenodd"
+                  d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+            </a>
           </div>
         </div>
       </div>
@@ -103,7 +120,6 @@
           Logout
         </button>
       </div>
-    </div>
     </div>
 
     <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">

--- a/frontend/public/demo.html
+++ b/frontend/public/demo.html
@@ -21,19 +21,28 @@
     <nav class="bg-white shadow-sm border-b border-gray-200">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between items-center h-16">
-          <div class="flex items-center">
-            <h1 class="text-xl font-bold text-gray-900">OAuth2 Flow Demo</h1>
+          <!-- Left: Logo & Title -->
+          <div class="flex items-center space-x-3">
+            <a href="hub.html" class="flex items-center space-x-3">
+              <img src="/img/credo-logo.svg" alt="Credo" class="h-9 w-9" />
+              <span class="text-xl font-bold text-gray-900">Credo</span>
+            </a>
+            <span class="text-gray-300">|</span>
+            <span class="text-lg font-medium text-gray-700">OAuth2 Flow Demo</span>
+            <span class="px-2 py-1 text-xs font-semibold rounded bg-blue-100 text-blue-700">PRD-001</span>
           </div>
+
+          <!-- Right: Navigation -->
           <div class="flex items-center space-x-4">
             <a
-              href="consent-demo.html"
-              class="text-sm text-green-600 hover:text-green-800 font-medium"
-              >Consent Demo</a
+              href="hub.html"
+              class="text-sm text-blue-600 hover:text-blue-800 font-medium"
+              >← Demo Hub</a
             >
             <a
-              href="attacks.html"
-              class="text-sm text-red-600 hover:text-red-900 font-semibold"
-              >⚠️ Attack Paths</a
+              href="admin.html"
+              class="text-sm text-gray-600 hover:text-gray-900"
+              >Admin</a
             >
             <a
               href="index.html"
@@ -41,10 +50,20 @@
               >User Portal</a
             >
             <a
-              href="admin.html"
-              class="text-sm text-gray-600 hover:text-gray-900"
-              >Admin View</a
+              href="https://github.com/abramin/Credo"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-gray-500 hover:text-gray-700"
+              title="View on GitHub"
             >
+              <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
+                <path
+                  fill-rule="evenodd"
+                  d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+            </a>
           </div>
         </div>
       </div>

--- a/frontend/public/hub.html
+++ b/frontend/public/hub.html
@@ -1,0 +1,427 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Credo - Demo Hub</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script
+      defer
+      src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"
+    ></script>
+    <link rel="stylesheet" href="/css/styles.css" />
+  </head>
+  <body class="bg-gray-50 min-h-screen">
+    <!-- Demo Warning Banner -->
+    <div
+      style="
+        background: #fff3cd;
+        color: #664d03;
+        padding: 10px;
+        font-size: 14px;
+        border-bottom: 1px solid #ffeeba;
+        text-align: center;
+      "
+    >
+      Demo environment only. No real identity data is processed or stored.
+    </div>
+
+    <!-- Navigation -->
+    <nav class="bg-white shadow-sm border-b border-gray-200">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="flex justify-between items-center h-16">
+          <!-- Left: Logo & Title -->
+          <div class="flex items-center space-x-3">
+            <img src="/img/credo-logo.svg" alt="Credo" class="h-9 w-9" />
+            <span class="text-xl font-bold text-gray-900">Credo</span>
+          </div>
+
+          <!-- Right: Navigation -->
+          <div class="flex items-center space-x-6">
+            <a
+              href="hub.html"
+              class="text-sm font-medium text-blue-600 hover:text-blue-800"
+              >Demo Hub</a
+            >
+            <a
+              href="admin.html"
+              class="text-sm text-gray-600 hover:text-gray-900"
+              >Admin</a
+            >
+            <a
+              href="index.html"
+              class="text-sm text-gray-600 hover:text-gray-900"
+              >User Portal</a
+            >
+            <a
+              href="https://github.com/abramin/Credo"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-gray-500 hover:text-gray-700"
+              title="View on GitHub"
+            >
+              <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
+                <path
+                  fill-rule="evenodd"
+                  d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </nav>
+
+    <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <!-- Hero Section -->
+      <div class="text-center mb-12">
+        <div class="flex justify-center mb-6">
+          <img src="/img/credo-logo.svg" alt="Credo" class="h-24 w-24" />
+        </div>
+        <h1 class="text-4xl font-bold text-gray-900 mb-4">
+          Credo Identity Platform
+        </h1>
+        <p class="text-lg text-gray-600 max-w-2xl mx-auto">
+          Privacy-first identity verification and consent management.
+          Explore interactive demos showcasing OAuth2, consent lifecycle,
+          verifiable credentials, and security best practices.
+        </p>
+      </div>
+
+      <!-- Portals Section -->
+      <div class="mb-12">
+        <h2 class="text-lg font-semibold text-gray-500 uppercase tracking-wide mb-6">
+          Portals
+        </h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <!-- User Portal -->
+          <a
+            href="index.html"
+            class="group bg-white rounded-xl shadow-md border border-gray-200 p-6 hover:shadow-lg hover:border-blue-300 transition-all"
+          >
+            <div class="flex items-start space-x-4">
+              <div
+                class="flex-shrink-0 w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center text-2xl"
+              >
+                👤
+              </div>
+              <div class="flex-1">
+                <h3
+                  class="text-lg font-semibold text-gray-900 group-hover:text-blue-600"
+                >
+                  User Portal
+                </h3>
+                <p class="text-sm text-gray-600 mt-1">
+                  End-user experience for identity verification, consent
+                  management, and data rights (GDPR export/delete).
+                </p>
+                <div class="flex items-center mt-3 text-sm text-blue-600">
+                  <span>Enter portal</span>
+                  <svg
+                    class="w-4 h-4 ml-1 group-hover:translate-x-1 transition-transform"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M9 5l7 7-7 7"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </div>
+          </a>
+
+          <!-- Admin Dashboard -->
+          <a
+            href="admin.html"
+            class="group bg-white rounded-xl shadow-md border border-gray-200 p-6 hover:shadow-lg hover:border-purple-300 transition-all"
+          >
+            <div class="flex items-start space-x-4">
+              <div
+                class="flex-shrink-0 w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center text-2xl"
+              >
+                🛡️
+              </div>
+              <div class="flex-1">
+                <h3
+                  class="text-lg font-semibold text-gray-900 group-hover:text-purple-600"
+                >
+                  Admin Dashboard
+                </h3>
+                <p class="text-sm text-gray-600 mt-1">
+                  Administrative view with audit logs, user sessions, consent
+                  statistics, and regulated mode comparison.
+                </p>
+                <div class="flex items-center mt-3 text-sm text-purple-600">
+                  <span>Enter dashboard</span>
+                  <svg
+                    class="w-4 h-4 ml-1 group-hover:translate-x-1 transition-transform"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M9 5l7 7-7 7"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </div>
+          </a>
+        </div>
+      </div>
+
+      <!-- Feature Demos Section -->
+      <div class="mb-12">
+        <h2 class="text-lg font-semibold text-gray-500 uppercase tracking-wide mb-6">
+          Feature Demos
+        </h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <!-- OAuth2 Flow Demo -->
+          <a
+            href="demo.html"
+            class="group bg-white rounded-xl shadow-md border border-gray-200 p-6 hover:shadow-lg hover:border-blue-300 transition-all"
+          >
+            <div class="flex items-center justify-between mb-4">
+              <div
+                class="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center text-xl"
+              >
+                🔑
+              </div>
+              <span
+                class="text-xs font-medium px-2 py-1 bg-blue-100 text-blue-700 rounded"
+                >PRD-001</span
+              >
+            </div>
+            <h3
+              class="text-lg font-semibold text-gray-900 group-hover:text-blue-600"
+            >
+              OAuth2 Flow
+            </h3>
+            <p class="text-sm text-gray-600 mt-2">
+              Interactive walkthrough of the OAuth2 Authorization Code flow with
+              JWT inspection and token exchange.
+            </p>
+          </a>
+
+          <!-- Consent Management Demo -->
+          <a
+            href="consent-demo.html"
+            class="group bg-white rounded-xl shadow-md border border-gray-200 p-6 hover:shadow-lg hover:border-green-300 transition-all"
+          >
+            <div class="flex items-center justify-between mb-4">
+              <div
+                class="w-10 h-10 bg-green-100 rounded-lg flex items-center justify-center text-xl"
+              >
+                ✅
+              </div>
+              <span
+                class="text-xs font-medium px-2 py-1 bg-green-100 text-green-700 rounded"
+                >PRD-002</span
+              >
+            </div>
+            <h3
+              class="text-lg font-semibold text-gray-900 group-hover:text-green-600"
+            >
+              Consent Management
+            </h3>
+            <p class="text-sm text-gray-600 mt-2">
+              Grant, list, and revoke user consents with TTL expiration and
+              idempotency window demonstration.
+            </p>
+          </a>
+
+          <!-- Verifiable Credentials (coming soon) -->
+          <div
+            class="bg-gray-50 rounded-xl border border-dashed border-gray-300 p-6 opacity-60"
+          >
+            <div class="flex items-center justify-between mb-4">
+              <div
+                class="w-10 h-10 bg-gray-200 rounded-lg flex items-center justify-center text-xl"
+              >
+                📜
+              </div>
+              <span
+                class="text-xs font-medium px-2 py-1 bg-gray-200 text-gray-600 rounded"
+                >PRD-004</span
+              >
+            </div>
+            <h3 class="text-lg font-semibold text-gray-500">
+              Verifiable Credentials
+            </h3>
+            <p class="text-sm text-gray-400 mt-2">
+              Issue and verify W3C-compliant credentials for age verification
+              and identity claims.
+            </p>
+            <span class="text-xs text-gray-400 mt-3 block">Coming soon</span>
+          </div>
+
+          <!-- Decision Engine (coming soon) -->
+          <div
+            class="bg-gray-50 rounded-xl border border-dashed border-gray-300 p-6 opacity-60"
+          >
+            <div class="flex items-center justify-between mb-4">
+              <div
+                class="w-10 h-10 bg-gray-200 rounded-lg flex items-center justify-center text-xl"
+              >
+                ⚖️
+              </div>
+              <span
+                class="text-xs font-medium px-2 py-1 bg-gray-200 text-gray-600 rounded"
+                >PRD-005</span
+              >
+            </div>
+            <h3 class="text-lg font-semibold text-gray-500">Decision Engine</h3>
+            <p class="text-sm text-gray-400 mt-2">
+              Evaluate identity decisions with configurable rules, consent
+              checks, and audit trails.
+            </p>
+            <span class="text-xs text-gray-400 mt-3 block">Coming soon</span>
+          </div>
+
+          <!-- Registry Integration (coming soon) -->
+          <div
+            class="bg-gray-50 rounded-xl border border-dashed border-gray-300 p-6 opacity-60"
+          >
+            <div class="flex items-center justify-between mb-4">
+              <div
+                class="w-10 h-10 bg-gray-200 rounded-lg flex items-center justify-center text-xl"
+              >
+                🏛️
+              </div>
+              <span
+                class="text-xs font-medium px-2 py-1 bg-gray-200 text-gray-600 rounded"
+                >PRD-003</span
+              >
+            </div>
+            <h3 class="text-lg font-semibold text-gray-500">
+              Registry Integration
+            </h3>
+            <p class="text-sm text-gray-400 mt-2">
+              Connect to citizen registries and sanctions lists with regulated
+              mode data minimization.
+            </p>
+            <span class="text-xs text-gray-400 mt-3 block">Coming soon</span>
+          </div>
+
+          <!-- GDPR Rights (coming soon) -->
+          <div
+            class="bg-gray-50 rounded-xl border border-dashed border-gray-300 p-6 opacity-60"
+          >
+            <div class="flex items-center justify-between mb-4">
+              <div
+                class="w-10 h-10 bg-gray-200 rounded-lg flex items-center justify-center text-xl"
+              >
+                🇪🇺
+              </div>
+              <span
+                class="text-xs font-medium px-2 py-1 bg-gray-200 text-gray-600 rounded"
+                >PRD-006/007</span
+              >
+            </div>
+            <h3 class="text-lg font-semibold text-gray-500">GDPR Data Rights</h3>
+            <p class="text-sm text-gray-400 mt-2">
+              Exercise data portability (export) and right to erasure (delete)
+              under GDPR compliance.
+            </p>
+            <span class="text-xs text-gray-400 mt-3 block">Coming soon</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Security Section -->
+      <div>
+        <h2 class="text-lg font-semibold text-gray-500 uppercase tracking-wide mb-6">
+          Security Education
+        </h2>
+        <div class="grid grid-cols-1 gap-6">
+          <!-- Attack Paths -->
+          <a
+            href="attacks.html"
+            class="group bg-gradient-to-r from-red-50 to-orange-50 rounded-xl shadow-md border border-red-200 p-6 hover:shadow-lg hover:border-red-400 transition-all"
+          >
+            <div class="flex items-start space-x-4">
+              <div
+                class="flex-shrink-0 w-12 h-12 bg-red-100 rounded-lg flex items-center justify-center text-2xl"
+              >
+                ⚠️
+              </div>
+              <div class="flex-1">
+                <div class="flex items-center space-x-2">
+                  <h3
+                    class="text-lg font-semibold text-gray-900 group-hover:text-red-600"
+                  >
+                    OAuth2 Attack Paths
+                  </h3>
+                  <span
+                    class="text-xs font-medium px-2 py-1 bg-red-100 text-red-700 rounded"
+                    >Security</span
+                  >
+                </div>
+                <p class="text-sm text-gray-600 mt-2">
+                  Interactive visualization of common OAuth2 security
+                  vulnerabilities including code interception, redirect URI
+                  manipulation, PKCE bypass, and token theft. Learn attack
+                  vectors and mitigation strategies.
+                </p>
+                <div class="flex items-center mt-3 text-sm text-red-600">
+                  <span>Explore attack scenarios</span>
+                  <svg
+                    class="w-4 h-4 ml-1 group-hover:translate-x-1 transition-transform"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M9 5l7 7-7 7"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </div>
+          </a>
+        </div>
+      </div>
+    </main>
+
+    <!-- Footer -->
+    <footer class="bg-white border-t border-gray-200 mt-16">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div class="flex items-center justify-between">
+          <div class="flex items-center space-x-3">
+            <img src="/img/credo-logo.svg" alt="Credo" class="h-6 w-6" />
+            <span class="text-sm text-gray-500"
+              >Privacy-first identity verification</span
+            >
+          </div>
+          <a
+            href="https://github.com/abramin/Credo"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-sm text-gray-500 hover:text-gray-700 flex items-center space-x-1"
+          >
+            <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+              <path
+                fill-rule="evenodd"
+                d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+                clip-rule="evenodd"
+              />
+            </svg>
+            <span>View on GitHub</span>
+          </a>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/frontend/public/img/credo-logo.svg
+++ b/frontend/public/img/credo-logo.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none">
+  <!-- Main icon group -->
+  <g fill="#2d2d2d" stroke="#2d2d2d" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+    <!-- Left rectangle with person icon -->
+    <rect x="12" y="15" width="36" height="50" rx="2" fill="none"/>
+    <!-- Circle (head) -->
+    <circle cx="30" cy="30" r="7" fill="#2d2d2d"/>
+    <!-- Body line -->
+    <line x1="30" y1="42" x2="30" y2="58" stroke-width="5"/>
+
+    <!-- Two vertical bars on right -->
+    <line x1="58" y1="15" x2="58" y2="65" stroke-width="6"/>
+    <line x1="74" y1="15" x2="74" y2="65" stroke-width="6"/>
+
+    <!-- Bottom bowl/curve -->
+    <path d="M 20 75 Q 45 95 70 75" fill="none" stroke-width="6"/>
+  </g>
+</svg>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -28,51 +28,64 @@
     <nav class="bg-white shadow-sm border-b border-gray-200">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between items-center h-16">
-          <div class="flex items-center">
-            <h1 class="text-xl font-bold text-gray-900">Credo</h1>
+          <!-- Left: Logo & Title -->
+          <div class="flex items-center space-x-3">
+            <a href="hub.html" class="flex items-center space-x-3">
+              <img src="/img/credo-logo.svg" alt="Credo" class="h-9 w-9" />
+              <span class="text-xl font-bold text-gray-900">Credo</span>
+            </a>
+            <span class="text-gray-300">|</span>
+            <span class="text-lg font-medium text-gray-700">User Portal</span>
             <span
-              class="ml-4 px-2 py-1 text-xs font-semibold rounded"
+              class="px-2 py-1 text-xs font-semibold rounded"
               :class="regulatedMode ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'"
             >
               <span
-                x-text="regulatedMode ? 'REGULATED MODE' : 'STANDARD MODE'"
+                x-text="regulatedMode ? '🔒 Regulated' : 'Standard'"
               ></span>
             </span>
           </div>
+
+          <!-- Right: Navigation -->
           <div class="flex items-center space-x-4">
-            <a
-              href="demo.html"
-              class="text-sm text-blue-600 hover:text-blue-800 font-medium"
-              >OAuth Demo</a
-            >
-            <a
-              href="consent-demo.html"
-              class="text-sm text-green-600 hover:text-green-800 font-medium"
-              >Consent Demo</a
-            >
-            <a
-              href="attacks.html"
-              class="text-sm text-red-600 hover:text-red-900 font-semibold"
-              >⚠️ Attack Paths</a
-            >
-            <template x-if="!isAuthenticated">
-              <a
-                href="admin.html"
-                class="text-sm text-gray-600 hover:text-gray-900"
-                >Admin View</a
-              >
-            </template>
             <template x-if="isAuthenticated">
-              <div class="flex items-center space-x-4">
+              <div class="flex items-center space-x-3 pr-4 border-r border-gray-200">
                 <span class="text-sm text-gray-600" x-text="userEmail"></span>
                 <button
                   @click="logout"
-                  class="text-sm text-red-600 hover:text-red-800"
+                  class="text-sm px-2 py-1 rounded border border-gray-300 text-gray-600 hover:border-red-400 hover:text-red-600"
+                  title="Logout"
                 >
-                  Logout
+                  🚪
                 </button>
               </div>
             </template>
+
+            <a
+              href="hub.html"
+              class="text-sm text-gray-600 hover:text-gray-900"
+              >Demo Hub</a
+            >
+            <a
+              href="admin.html"
+              class="text-sm text-gray-600 hover:text-gray-900"
+              >Admin</a
+            >
+            <a
+              href="https://github.com/abramin/Credo"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-gray-500 hover:text-gray-700"
+              title="View on GitHub"
+            >
+              <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
+                <path
+                  fill-rule="evenodd"
+                  d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+            </a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
- Create hub.html as central landing page with categorized demo cards
- Add Credo logo SVG asset (/img/credo-logo.svg)
- Unify navigation across all pages with logo, Demo Hub link, and GitHub link
- Clean up cluttered admin navbar by grouping utility actions
- Add "← Demo Hub" breadcrumb links on demo pages for easy return
- Include PRD badges on demo pages (PRD-001, PRD-002, Security)
- Add placeholder cards for upcoming features (VC, Decision Engine, Registry, GDPR)