### PR TITLE
Explore payment-adjacent features for Credo

### DIFF
--- a/docs/prd/PRD-035-Identity-Assurance-Levels.md
+++ b/docs/prd/PRD-035-Identity-Assurance-Levels.md
@@ -1,0 +1,484 @@
+# PRD-035: Identity Assurance Levels
+
+**Status:** Not Started
+**Priority:** P1 (High - Banking/Fintech)
+**Owner:** Engineering Team
+**Dependencies:** PRD-004 (Verifiable Credentials), PRD-003 (Registry Integration), PRD-006 (Audit)
+**Phase:** 8 (Banking Identity Pack)
+**Last Updated:** 2025-12-22
+
+---
+
+## 1. Overview
+
+### Problem Statement
+
+Banks and regulated financial services don't just need "is this user authenticated?" — they need "how confident are we in this identity?" Current Credo VCs prove specific facts (e.g., "is over 18") but don't track the **strength of identity proofing** used to establish those facts.
+
+Identity Assurance Levels (IALs) answer:
+- **How was this identity verified?** (document scan, video call, in-branch, eID)
+- **How recently?** (some proofing methods decay in trust over time)
+- **What can this assurance level unlock?** (higher IAL = higher transaction limits)
+
+Without IALs, a bank cannot implement tiered access: "LoA1 users can view balances; LoA3 users can transfer €50k."
+
+### Goals
+
+- Define Identity Assurance Levels aligned with eIDAS/NIST 800-63-3
+- Track proofing method, verification timestamp, and expiry per user
+- Store verified claims with their assurance context
+- Expose IAL in tokens and API responses for downstream policy decisions
+- Enable policy rules based on IAL (via PRD-015/PRD-027)
+
+### Non-Goals
+
+- Implementing actual identity proofing (document scanning, video ident) — Credo consumes external IDV providers
+- Biometric storage (see PRD-013)
+- Credential wallet / holder-side storage
+- Cross-tenant IAL portability (each tenant maintains own assurance records)
+
+---
+
+## 2. User Stories
+
+**As a bank compliance officer**
+**I want to** require IAL2+ for account opening and IAL3 for high-value transfers
+**So that** we meet regulatory KYC requirements
+
+**As a fintech product manager**
+**I want to** offer tiered onboarding (IAL1 for browsing, IAL2 for transactions)
+**So that** users can start quickly and upgrade when needed
+
+**As a security engineer**
+**I want to** see the proofing method and timestamp in audit logs
+**So that** I can investigate identity-related incidents
+
+**As a user**
+**I want to** know what verification is required to unlock higher limits
+**So that** I can complete verification proactively
+
+---
+
+## 3. Functional Requirements
+
+### FR-1: Assurance Level Model
+
+**Levels (eIDAS-aligned):**
+
+| Level | Name | Description | Example Methods |
+|-------|------|-------------|-----------------|
+| IAL0 | No Proofing | Self-asserted identity | Email signup only |
+| IAL1 | Low | Basic identity verification | Email + phone verified |
+| IAL2 | Substantial | Identity document verification | Document scan + selfie match |
+| IAL3 | High | In-person or supervised remote | Video ident, in-branch, eID |
+
+**Proofing Methods:**
+
+```go
+type ProofingMethod string
+
+const (
+    ProofingNone          ProofingMethod = "none"           // Self-asserted
+    ProofingEmailVerified ProofingMethod = "email_verified" // Email OTP confirmed
+    ProofingPhoneVerified ProofingMethod = "phone_verified" // SMS OTP confirmed
+    ProofingDocumentScan  ProofingMethod = "document_scan"  // ID document OCR + verification
+    ProofingSelfieMatch   ProofingMethod = "selfie_match"   // Liveness + face match to document
+    ProofingVideoIdent    ProofingMethod = "video_ident"    // Live video call with agent
+    ProofingInBranch      ProofingMethod = "in_branch"      // Physical presence verification
+    ProofingEID           ProofingMethod = "eid"            // Government eID (e.g., German Ausweis)
+    ProofingBankVerified  ProofingMethod = "bank_verified"  // Verified via bank account ownership
+)
+```
+
+### FR-2: Identity Assurance Record
+
+**Endpoint:** `POST /identity/assurance` (internal/admin)
+
+**Description:** Record identity proofing result from external IDV provider.
+
+**Input:**
+
+```json
+{
+  "user_id": "user_abc123",
+  "level": "IAL2",
+  "proofing_method": "document_scan",
+  "provider": "onfido",
+  "provider_reference": "check_xyz789",
+  "verified_claims": [
+    {"claim": "full_name", "value": "Alice Smith", "confidence": 0.95},
+    {"claim": "date_of_birth", "value": "1990-05-15", "confidence": 0.98},
+    {"claim": "nationality", "value": "DE", "confidence": 0.92},
+    {"claim": "document_number", "value": "L01X...", "confidence": 0.99}
+  ],
+  "document_type": "passport",
+  "document_country": "DE",
+  "expires_at": "2026-12-22T00:00:00Z"
+}
+```
+
+**Output (Success - 201):**
+
+```json
+{
+  "assurance_id": "ial_def456",
+  "user_id": "user_abc123",
+  "level": "IAL2",
+  "proofing_method": "document_scan",
+  "verified_at": "2025-12-22T10:30:00Z",
+  "expires_at": "2026-12-22T00:00:00Z",
+  "claims_count": 4
+}
+```
+
+**Business Logic:**
+
+1. Validate user exists and belongs to tenant
+2. Validate level is recognized (IAL0-IAL3)
+3. Validate proofing method is appropriate for level
+4. Store assurance record with verified claims
+5. Update user's current IAL if this is higher
+6. Emit audit event `identity.assurance_recorded`
+7. If regulated mode, store only derived flags (not raw PII)
+
+### FR-3: Query User Assurance
+
+**Endpoint:** `GET /identity/assurance/{user_id}`
+
+**Description:** Get current identity assurance level and history.
+
+**Output:**
+
+```json
+{
+  "user_id": "user_abc123",
+  "current_level": "IAL2",
+  "current_method": "document_scan",
+  "verified_at": "2025-12-22T10:30:00Z",
+  "expires_at": "2026-12-22T00:00:00Z",
+  "is_expired": false,
+  "history": [
+    {
+      "assurance_id": "ial_def456",
+      "level": "IAL2",
+      "method": "document_scan",
+      "verified_at": "2025-12-22T10:30:00Z"
+    },
+    {
+      "assurance_id": "ial_abc123",
+      "level": "IAL1",
+      "method": "email_verified",
+      "verified_at": "2025-12-01T08:00:00Z"
+    }
+  ]
+}
+```
+
+### FR-4: Require Assurance Level
+
+**Endpoint:** `POST /identity/assurance/require` (service-to-service)
+
+**Description:** Check if user meets minimum assurance level for an operation.
+
+**Input:**
+
+```json
+{
+  "user_id": "user_abc123",
+  "required_level": "IAL2",
+  "operation": "transfer_initiate",
+  "amount": 5000,
+  "currency": "EUR"
+}
+```
+
+**Output (Success - 200):**
+
+```json
+{
+  "allowed": true,
+  "current_level": "IAL2",
+  "required_level": "IAL2",
+  "verified_at": "2025-12-22T10:30:00Z"
+}
+```
+
+**Output (Insufficient - 403):**
+
+```json
+{
+  "allowed": false,
+  "current_level": "IAL1",
+  "required_level": "IAL2",
+  "upgrade_url": "/identity/upgrade?target=IAL2",
+  "reason": "identity_assurance_insufficient"
+}
+```
+
+### FR-5: Token Claims
+
+Access tokens include assurance level when requested via scope:
+
+**Scope:** `identity_assurance`
+
+**Claims:**
+
+```json
+{
+  "ial": "IAL2",
+  "ial_method": "document_scan",
+  "ial_verified_at": "2025-12-22T10:30:00Z",
+  "ial_expires_at": "2026-12-22T00:00:00Z"
+}
+```
+
+### FR-6: Assurance Expiry & Decay
+
+- Document-based proofing (IAL2) valid for 12 months by default
+- Video ident (IAL3) valid for 24 months
+- eID (IAL3) valid until document expiry
+- Expired assurance demotes user to previous valid level
+- Configurable per tenant via policy
+
+---
+
+## 4. Technical Requirements
+
+### TR-1: Data Models
+
+```go
+// internal/identity/assurance/models.go
+
+type AssuranceLevel string
+
+const (
+    IAL0 AssuranceLevel = "IAL0" // No proofing
+    IAL1 AssuranceLevel = "IAL1" // Low
+    IAL2 AssuranceLevel = "IAL2" // Substantial
+    IAL3 AssuranceLevel = "IAL3" // High
+)
+
+func (l AssuranceLevel) Rank() int {
+    switch l {
+    case IAL0: return 0
+    case IAL1: return 1
+    case IAL2: return 2
+    case IAL3: return 3
+    default: return -1
+    }
+}
+
+func (l AssuranceLevel) MeetsOrExceeds(required AssuranceLevel) bool {
+    return l.Rank() >= required.Rank()
+}
+
+type AssuranceRecord struct {
+    ID              id.AssuranceID
+    UserID          id.UserID
+    TenantID        id.TenantID
+    Level           AssuranceLevel
+    ProofingMethod  ProofingMethod
+    Provider        string            // External IDV provider
+    ProviderRef     string            // External reference ID
+    VerifiedClaims  []VerifiedClaim   // What was proven
+    DocumentType    *string           // passport, id_card, drivers_license
+    DocumentCountry *string           // ISO 3166-1 alpha-2
+    VerifiedAt      time.Time
+    ExpiresAt       *time.Time
+    RevokedAt       *time.Time
+    RevokedReason   *string
+    CreatedAt       time.Time
+}
+
+type VerifiedClaim struct {
+    Claim      string  // full_name, date_of_birth, nationality, etc.
+    Value      string  // Encrypted or hashed in regulated mode
+    Confidence float64 // 0.0 - 1.0
+}
+
+type UserAssuranceState struct {
+    UserID          id.UserID
+    CurrentLevel    AssuranceLevel
+    CurrentMethod   ProofingMethod
+    VerifiedAt      time.Time
+    ExpiresAt       *time.Time
+    IsExpired       bool
+    History         []AssuranceRecord
+}
+```
+
+### TR-2: Store Interface
+
+```go
+type AssuranceStore interface {
+    Save(ctx context.Context, record *AssuranceRecord) error
+    FindByID(ctx context.Context, id id.AssuranceID) (*AssuranceRecord, error)
+    FindByUser(ctx context.Context, userID id.UserID) ([]AssuranceRecord, error)
+    FindCurrentByUser(ctx context.Context, userID id.UserID) (*AssuranceRecord, error)
+    Revoke(ctx context.Context, id id.AssuranceID, reason string) error
+    DeleteByUser(ctx context.Context, userID id.UserID) error // GDPR
+}
+```
+
+### TR-3: Service Layer
+
+```go
+type AssuranceService struct {
+    store   AssuranceStore
+    auditor audit.Publisher
+    config  AssuranceConfig
+}
+
+func (s *AssuranceService) RecordAssurance(ctx context.Context, req RecordAssuranceRequest) (*AssuranceRecord, error)
+func (s *AssuranceService) GetUserAssurance(ctx context.Context, userID id.UserID) (*UserAssuranceState, error)
+func (s *AssuranceService) RequireLevel(ctx context.Context, userID id.UserID, required AssuranceLevel) error
+func (s *AssuranceService) RevokeAssurance(ctx context.Context, assuranceID id.AssuranceID, reason string) error
+```
+
+### TR-4: Integration with Decision Engine (PRD-005)
+
+The decision engine can query assurance level as evidence:
+
+```go
+// Evidence signal for decision engine
+type AssuranceEvidence struct {
+    Level        AssuranceLevel
+    Method       ProofingMethod
+    VerifiedAt   time.Time
+    IsExpired    bool
+    DaysSinceVerification int
+}
+```
+
+### TR-5: Regulated Mode Handling
+
+In `REGULATED_MODE=true`:
+- `VerifiedClaim.Value` is hashed, not stored in cleartext
+- API responses return only derived flags (`has_verified_name: true`)
+- Full claim values never exposed via API
+
+---
+
+## 5. API Specifications
+
+| Endpoint | Method | Auth | Purpose |
+|----------|--------|------|---------|
+| `/identity/assurance` | POST | Admin/Service | Record new assurance |
+| `/identity/assurance/{user_id}` | GET | Bearer | Get user assurance state |
+| `/identity/assurance/require` | POST | Service | Check assurance requirement |
+| `/identity/assurance/{id}/revoke` | POST | Admin | Revoke assurance record |
+| `/admin/assurance/policies` | GET/PUT | Admin | Configure tenant assurance policies |
+
+---
+
+## 6. Security Requirements
+
+### SR-1: Data Protection
+- Verified claims encrypted at rest
+- PII never logged (only assurance IDs and levels)
+- Provider references stored for audit trail only
+
+### SR-2: Access Control
+- Recording assurance requires admin or service-to-service auth
+- Users can view their own assurance state
+- Cross-tenant access prohibited
+
+### SR-3: Audit Trail
+- All assurance changes logged with actor, timestamp, reason
+- Revocation requires documented reason
+- History preserved for compliance (7 years default)
+
+---
+
+## 7. Observability
+
+### Metrics
+
+```
+# Gauge: Users at each assurance level per tenant
+identity_assurance_users_by_level{tenant_id, level}
+
+# Counter: Assurance verifications recorded
+identity_assurance_recorded_total{level, method, provider}
+
+# Counter: Assurance checks (require) by outcome
+identity_assurance_checks_total{required_level, outcome="allowed|denied"}
+
+# Counter: Expired assurances
+identity_assurance_expired_total{level}
+```
+
+### Audit Events
+
+- `identity.assurance_recorded` - New assurance added
+- `identity.assurance_required_passed` - Check passed
+- `identity.assurance_required_failed` - Check failed
+- `identity.assurance_revoked` - Manually revoked
+- `identity.assurance_expired` - Auto-expired
+
+---
+
+## 8. Acceptance Criteria
+
+- [ ] IAL0-IAL3 levels defined and stored per user
+- [ ] Proofing method recorded with each assurance
+- [ ] Assurance expiry enforced (demotes to previous level)
+- [ ] Token claims include IAL when `identity_assurance` scope requested
+- [ ] Require endpoint returns upgrade URL on insufficient assurance
+- [ ] Regulated mode hashes claim values
+- [ ] Audit trail for all assurance operations
+- [ ] Integration with decision engine (PRD-005) for policy evaluation
+- [ ] GDPR deletion removes assurance records
+
+---
+
+## 9. Implementation Steps
+
+### Phase 1: Foundation (4-6 hours)
+1. Define domain models and value objects
+2. Implement AssuranceStore (in-memory, then PostgreSQL)
+3. Implement AssuranceService core methods
+4. Unit tests
+
+### Phase 2: API Layer (2-3 hours)
+1. HTTP handlers for record/query/require
+2. Request validation
+3. Integration tests
+
+### Phase 3: Token Integration (2 hours)
+1. Add `identity_assurance` scope
+2. Include IAL claims in access tokens
+3. Update token validation
+
+### Phase 4: Decision Engine Integration (2 hours)
+1. Expose assurance as evidence signal
+2. Policy examples for IAL-based decisions
+3. E2E tests
+
+---
+
+## 10. Future Enhancements
+
+- IDV provider integrations (Onfido, Jumio, IDnow)
+- Progressive verification flows (step-up from IAL1 to IAL2)
+- Assurance level inheritance (IAL3 implies IAL2 claims)
+- Cross-border assurance recognition (eIDAS interoperability)
+- Assurance score (continuous, not just levels)
+
+---
+
+## 11. References
+
+- [eIDAS Regulation](https://digital-strategy.ec.europa.eu/en/policies/eidas-regulation)
+- [NIST SP 800-63-3: Digital Identity Guidelines](https://pages.nist.gov/800-63-3/)
+- [ISO/IEC 29115:2013 Entity Authentication Assurance](https://www.iso.org/standard/45138.html)
+- PRD-004: Verifiable Credentials
+- PRD-005: Decision Engine
+
+---
+
+## Revision History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2025-12-22 | Engineering | Initial PRD |

--- a/docs/prd/PRD-036-Legal-Entity-Identity.md
+++ b/docs/prd/PRD-036-Legal-Entity-Identity.md
@@ -1,0 +1,649 @@
+# PRD-036: Legal Entity Identity & Representation
+
+**Status:** Not Started
+**Priority:** P1 (High - Banking/Fintech)
+**Owner:** Engineering Team
+**Dependencies:** PRD-026A (Tenant & Client Management), PRD-035 (Identity Assurance), PRD-006 (Audit)
+**Phase:** 8 (Banking Identity Pack)
+**Last Updated:** 2025-12-22
+
+---
+
+## 1. Overview
+
+### Problem Statement
+
+Banks serve businesses, not just individuals. A business banking platform like Qonto needs to answer:
+- **Is this a legitimate legal entity?** (company registry verification)
+- **Who can act on behalf of this entity?** (directors, signatories, proxies)
+- **What powers do they have?** (full authority, limited to €X, specific actions only)
+- **Is their authority currently valid?** (not expired, not revoked)
+
+Current Credo has:
+- Users (individuals with email)
+- Tenants (isolated identity boundaries)
+
+Missing:
+- Legal entities (companies, organizations)
+- Representation relationships (user → entity with specific powers)
+- Signatory management (who can sign what)
+
+### Goals
+
+- Model **legal entities** as first-class identity subjects
+- Track entity verification status from company registries
+- Define **representation** relationships (user can act for entity)
+- Support **role-based powers** (director, signatory, proxy, accountant)
+- Enable policy decisions based on representation validity
+- Integrate with beneficial ownership for AML compliance
+
+### Non-Goals
+
+- Implementing company registry integrations (Credo consumes external providers)
+- Full UBO (Ultimate Beneficial Owner) graph resolution
+- Entity-to-entity relationships (subsidiaries, parent companies)
+- Legal entity account management (that's the banking system's job)
+
+---
+
+## 2. User Stories
+
+**As a bank compliance officer**
+**I want to** verify that a person is an authorized director of a company
+**So that** they can open accounts and sign contracts on behalf of the entity
+
+**As a business account holder**
+**I want to** delegate limited signing authority to my accountant
+**So that** they can approve small payments without my involvement
+
+**As a fintech platform**
+**I want to** check entity verification status before allowing transactions
+**So that** we only transact with verified, non-sanctioned businesses
+
+**As an auditor**
+**I want to** see the full history of who was authorized to act for an entity
+**So that** I can trace authorization for past transactions
+
+---
+
+## 3. Functional Requirements
+
+### FR-1: Legal Entity Model
+
+**Entity Types (EU-focused, extensible):**
+
+| Type | Description | Examples |
+|------|-------------|----------|
+| `gmbh` | German limited liability | GmbH, UG |
+| `ag` | German public company | AG |
+| `sas` | French simplified joint-stock | SAS |
+| `sarl` | French limited liability | SARL |
+| `ltd` | UK limited company | Ltd, PLC |
+| `bv` | Dutch private limited | B.V. |
+| `sole_trader` | Individual business | Einzelunternehmen |
+| `partnership` | General partnership | OHG, GbR |
+| `other` | Other entity types | Associations, foundations |
+
+**Entity Status:**
+
+```go
+type EntityStatus string
+
+const (
+    EntityStatusPending    EntityStatus = "pending"     // Awaiting verification
+    EntityStatusActive     EntityStatus = "active"      // Verified and operational
+    EntityStatusSuspended  EntityStatus = "suspended"   // Temporarily restricted
+    EntityStatusDissolved  EntityStatus = "dissolved"   // No longer exists
+    EntityStatusSanctioned EntityStatus = "sanctioned"  // On sanctions list
+)
+```
+
+### FR-2: Register Legal Entity
+
+**Endpoint:** `POST /entities`
+
+**Description:** Register a legal entity for verification.
+
+**Input:**
+
+```json
+{
+  "name": "Acme GmbH",
+  "entity_type": "gmbh",
+  "registration_number": "HRB 123456",
+  "registration_authority": "Amtsgericht München",
+  "jurisdiction": "DE",
+  "registered_address": {
+    "street": "Maximilianstraße 1",
+    "city": "München",
+    "postal_code": "80539",
+    "country": "DE"
+  },
+  "incorporation_date": "2020-01-15",
+  "tax_id": "DE123456789"
+}
+```
+
+**Output (Success - 201):**
+
+```json
+{
+  "entity_id": "ent_abc123",
+  "name": "Acme GmbH",
+  "entity_type": "gmbh",
+  "status": "pending",
+  "verification_required": true,
+  "created_at": "2025-12-22T10:00:00Z"
+}
+```
+
+**Business Logic:**
+
+1. Validate required fields (name, type, jurisdiction)
+2. Check for duplicate registration number in jurisdiction
+3. Create entity with `pending` status
+4. Queue for verification (external registry lookup)
+5. Emit audit event `entity.registered`
+
+### FR-3: Verify Entity
+
+**Endpoint:** `POST /entities/{id}/verify` (internal/admin)
+
+**Description:** Record verification result from company registry.
+
+**Input:**
+
+```json
+{
+  "provider": "company_house_de",
+  "provider_reference": "ref_xyz789",
+  "verification_result": "verified",
+  "verified_data": {
+    "name": "Acme GmbH",
+    "status": "active",
+    "incorporation_date": "2020-01-15",
+    "registered_directors": ["Alice Smith", "Bob Jones"],
+    "share_capital": "25000 EUR"
+  },
+  "sanctions_check": {
+    "checked_at": "2025-12-22T10:30:00Z",
+    "result": "clear",
+    "lists_checked": ["EU", "UN", "OFAC"]
+  }
+}
+```
+
+**Output (Success - 200):**
+
+```json
+{
+  "entity_id": "ent_abc123",
+  "status": "active",
+  "verified_at": "2025-12-22T10:30:00Z",
+  "verification_expires_at": "2026-12-22T00:00:00Z"
+}
+```
+
+### FR-4: Representation Model
+
+**Representation** links a user to an entity with specific powers.
+
+**Roles:**
+
+| Role | Description | Typical Powers |
+|------|-------------|----------------|
+| `director` | Legal representative | Full authority, sign contracts |
+| `signatory` | Authorized signer | Sign within limits |
+| `proxy` | Delegated authority | Specific powers, time-limited |
+| `accountant` | Financial access | View transactions, limited approvals |
+| `employee` | Basic access | View only, initiate requests |
+
+**Powers:**
+
+```go
+type Power string
+
+const (
+    PowerFullAuthority      Power = "full_authority"       // Can do anything
+    PowerSignContracts      Power = "sign_contracts"       // Legal agreements
+    PowerInitiateTransfers  Power = "initiate_transfers"   // Start payments
+    PowerApproveTransfers   Power = "approve_transfers"    // Approve payments
+    PowerViewTransactions   Power = "view_transactions"    // Read-only access
+    PowerManageCards        Power = "manage_cards"         // Card operations
+    PowerManageUsers        Power = "manage_users"         // Add/remove team
+    PowerManageBeneficiaries Power = "manage_beneficiaries" // Payment targets
+)
+```
+
+### FR-5: Create Representation
+
+**Endpoint:** `POST /entities/{entity_id}/representations`
+
+**Description:** Grant a user representation rights for an entity.
+
+**Input:**
+
+```json
+{
+  "user_id": "user_alice123",
+  "role": "signatory",
+  "powers": ["initiate_transfers", "approve_transfers"],
+  "constraints": {
+    "amount_limit": {
+      "max_single": 10000,
+      "max_daily": 50000,
+      "currency": "EUR"
+    },
+    "valid_from": "2025-12-22T00:00:00Z",
+    "valid_until": "2026-12-22T00:00:00Z",
+    "requires_sca": true
+  },
+  "granted_by": "user_bob456",
+  "evidence": {
+    "type": "board_resolution",
+    "reference": "doc_res123",
+    "date": "2025-12-20"
+  }
+}
+```
+
+**Output (Success - 201):**
+
+```json
+{
+  "representation_id": "rep_def456",
+  "entity_id": "ent_abc123",
+  "user_id": "user_alice123",
+  "role": "signatory",
+  "status": "active",
+  "powers": ["initiate_transfers", "approve_transfers"],
+  "valid_until": "2026-12-22T00:00:00Z",
+  "created_at": "2025-12-22T10:00:00Z"
+}
+```
+
+**Business Logic:**
+
+1. Validate entity exists and is active
+2. Validate user exists
+3. Validate grantor has authority to grant (is director or has `manage_users`)
+4. Check for conflicting representations
+5. Store representation with constraints
+6. Emit audit event `representation.granted`
+
+### FR-6: Check Representation
+
+**Endpoint:** `POST /entities/{entity_id}/representations/check`
+
+**Description:** Check if a user can perform an action for an entity.
+
+**Input:**
+
+```json
+{
+  "user_id": "user_alice123",
+  "power": "approve_transfers",
+  "context": {
+    "amount": 5000,
+    "currency": "EUR",
+    "action": "transfer_approval"
+  }
+}
+```
+
+**Output (Success - 200):**
+
+```json
+{
+  "allowed": true,
+  "representation_id": "rep_def456",
+  "role": "signatory",
+  "constraints_checked": {
+    "amount_within_limit": true,
+    "valid_time_range": true,
+    "sca_required": true
+  }
+}
+```
+
+**Output (Denied - 403):**
+
+```json
+{
+  "allowed": false,
+  "reason": "amount_exceeds_limit",
+  "representation_id": "rep_def456",
+  "constraint_violated": {
+    "type": "amount_limit",
+    "limit": 10000,
+    "requested": 15000,
+    "currency": "EUR"
+  }
+}
+```
+
+### FR-7: List Entity Representations
+
+**Endpoint:** `GET /entities/{entity_id}/representations`
+
+**Output:**
+
+```json
+{
+  "entity_id": "ent_abc123",
+  "representations": [
+    {
+      "representation_id": "rep_001",
+      "user_id": "user_alice",
+      "user_name": "Alice Smith",
+      "role": "director",
+      "status": "active",
+      "powers": ["full_authority"],
+      "valid_until": null
+    },
+    {
+      "representation_id": "rep_002",
+      "user_id": "user_bob",
+      "user_name": "Bob Jones",
+      "role": "signatory",
+      "status": "active",
+      "powers": ["initiate_transfers", "approve_transfers"],
+      "valid_until": "2026-12-22T00:00:00Z"
+    }
+  ]
+}
+```
+
+### FR-8: Revoke Representation
+
+**Endpoint:** `POST /entities/{entity_id}/representations/{rep_id}/revoke`
+
+**Input:**
+
+```json
+{
+  "reason": "employment_terminated",
+  "effective_immediately": true,
+  "revoked_by": "user_alice123"
+}
+```
+
+**Business Logic:**
+
+1. Validate revoker has authority
+2. Set representation status to `revoked`
+3. Set `revoked_at` timestamp
+4. Emit audit event `representation.revoked`
+5. Invalidate any active step-up tokens for this representation
+
+---
+
+## 4. Technical Requirements
+
+### TR-1: Data Models
+
+```go
+// internal/entity/models.go
+
+type LegalEntity struct {
+    ID                   id.EntityID
+    TenantID             id.TenantID
+    Name                 string
+    EntityType           EntityType
+    RegistrationNumber   string
+    RegistrationAuthority string
+    Jurisdiction         string        // ISO 3166-1 alpha-2
+    RegisteredAddress    Address
+    IncorporationDate    *time.Time
+    TaxID                *string
+    Status               EntityStatus
+    VerifiedAt           *time.Time
+    VerificationExpiresAt *time.Time
+    SanctionsStatus      SanctionsStatus
+    SanctionsCheckedAt   *time.Time
+    CreatedAt            time.Time
+    UpdatedAt            time.Time
+}
+
+type Representation struct {
+    ID           id.RepresentationID
+    EntityID     id.EntityID
+    UserID       id.UserID
+    TenantID     id.TenantID
+    Role         RepresentationRole
+    Powers       []Power
+    Constraints  *RepresentationConstraints
+    Status       RepresentationStatus  // active, suspended, revoked, expired
+    GrantedBy    id.UserID
+    Evidence     *RepresentationEvidence
+    ValidFrom    time.Time
+    ValidUntil   *time.Time
+    RevokedAt    *time.Time
+    RevokedBy    *id.UserID
+    RevokedReason *string
+    CreatedAt    time.Time
+    UpdatedAt    time.Time
+}
+
+type RepresentationConstraints struct {
+    AmountLimit    *AmountLimit
+    RequiresSCA    bool
+    AllowedActions []string  // Specific action types
+    TimeWindow     *TimeWindow  // e.g., business hours only
+}
+
+type AmountLimit struct {
+    MaxSingle  int64
+    MaxDaily   int64
+    MaxMonthly int64
+    Currency   string
+}
+
+type RepresentationEvidence struct {
+    Type       string    // board_resolution, power_of_attorney, employment_contract
+    Reference  string    // Document ID
+    Date       time.Time
+    VerifiedBy *id.UserID
+}
+```
+
+### TR-2: Store Interfaces
+
+```go
+type EntityStore interface {
+    Save(ctx context.Context, entity *LegalEntity) error
+    FindByID(ctx context.Context, id id.EntityID) (*LegalEntity, error)
+    FindByRegistration(ctx context.Context, regNum, jurisdiction string) (*LegalEntity, error)
+    FindByTenant(ctx context.Context, tenantID id.TenantID) ([]LegalEntity, error)
+    Update(ctx context.Context, entity *LegalEntity) error
+    Delete(ctx context.Context, id id.EntityID) error
+}
+
+type RepresentationStore interface {
+    Save(ctx context.Context, rep *Representation) error
+    FindByID(ctx context.Context, id id.RepresentationID) (*Representation, error)
+    FindByEntity(ctx context.Context, entityID id.EntityID) ([]Representation, error)
+    FindByUser(ctx context.Context, userID id.UserID) ([]Representation, error)
+    FindActiveByUserAndEntity(ctx context.Context, userID id.UserID, entityID id.EntityID) (*Representation, error)
+    Update(ctx context.Context, rep *Representation) error
+    Revoke(ctx context.Context, id id.RepresentationID, revokedBy id.UserID, reason string) error
+}
+```
+
+### TR-3: Service Layer
+
+```go
+type EntityService struct {
+    entities        EntityStore
+    representations RepresentationStore
+    sanctions       SanctionsChecker  // PRD-003
+    auditor         audit.Publisher
+}
+
+func (s *EntityService) RegisterEntity(ctx context.Context, req RegisterEntityRequest) (*LegalEntity, error)
+func (s *EntityService) VerifyEntity(ctx context.Context, req VerifyEntityRequest) (*LegalEntity, error)
+func (s *EntityService) GetEntity(ctx context.Context, entityID id.EntityID) (*LegalEntity, error)
+
+func (s *EntityService) GrantRepresentation(ctx context.Context, req GrantRepresentationRequest) (*Representation, error)
+func (s *EntityService) CheckRepresentation(ctx context.Context, req CheckRepresentationRequest) (*CheckResult, error)
+func (s *EntityService) RevokeRepresentation(ctx context.Context, req RevokeRepresentationRequest) error
+func (s *EntityService) ListRepresentations(ctx context.Context, entityID id.EntityID) ([]Representation, error)
+```
+
+### TR-4: Integration with Decision Engine
+
+Expose entity/representation as evidence for policy decisions:
+
+```go
+type EntityEvidence struct {
+    EntityID     id.EntityID
+    Status       EntityStatus
+    Verified     bool
+    Sanctioned   bool
+    DaysSinceVerification int
+}
+
+type RepresentationEvidence struct {
+    HasRepresentation bool
+    Role              RepresentationRole
+    Powers            []Power
+    WithinAmountLimit bool
+    ValidTimeRange    bool
+    RequiresSCA       bool
+}
+```
+
+---
+
+## 5. API Specifications
+
+| Endpoint | Method | Auth | Purpose |
+|----------|--------|------|---------|
+| `/entities` | POST | Bearer | Register new entity |
+| `/entities/{id}` | GET | Bearer | Get entity details |
+| `/entities/{id}/verify` | POST | Admin | Record verification |
+| `/entities/{id}/representations` | GET | Bearer | List representations |
+| `/entities/{id}/representations` | POST | Bearer | Grant representation |
+| `/entities/{id}/representations/check` | POST | Service | Check authorization |
+| `/entities/{id}/representations/{rep_id}` | GET | Bearer | Get representation |
+| `/entities/{id}/representations/{rep_id}/revoke` | POST | Bearer | Revoke representation |
+| `/users/{id}/representations` | GET | Bearer | User's representations |
+
+---
+
+## 6. Security Requirements
+
+### SR-1: Authorization Hierarchy
+- Only directors can grant director roles
+- Signatories cannot grant powers they don't have
+- Representation changes require valid representation
+- Self-revocation always allowed
+
+### SR-2: Audit Trail
+- All representation changes logged with evidence
+- Entity verification history preserved
+- Grantor/revoker identity recorded
+
+### SR-3: Sanctions Compliance
+- Sanctioned entities cannot have active representations
+- Periodic re-screening required (configurable interval)
+- Sanctions hit triggers immediate suspension
+
+---
+
+## 7. Observability
+
+### Metrics
+
+```
+# Gauge: Entities by status
+entity_count_by_status{tenant_id, status}
+
+# Counter: Entity verifications
+entity_verifications_total{result="verified|failed|pending"}
+
+# Counter: Representation operations
+representation_operations_total{operation="grant|revoke|check", result}
+
+# Counter: Authorization checks
+representation_checks_total{power, result="allowed|denied"}
+```
+
+### Audit Events
+
+- `entity.registered` - New entity created
+- `entity.verified` - Verification completed
+- `entity.suspended` - Entity suspended
+- `entity.sanctioned` - Sanctions hit detected
+- `representation.granted` - New representation
+- `representation.revoked` - Representation revoked
+- `representation.checked` - Authorization check performed
+- `representation.expired` - Auto-expired representation
+
+---
+
+## 8. Acceptance Criteria
+
+- [ ] Legal entities can be registered with type and jurisdiction
+- [ ] Entity verification status tracked from external providers
+- [ ] Representations link users to entities with roles and powers
+- [ ] Representation constraints enforced (amount limits, time validity)
+- [ ] Directors can grant/revoke representations
+- [ ] Check endpoint evaluates constraints in context
+- [ ] Sanctions status blocks operations for flagged entities
+- [ ] Audit trail captures all representation changes
+- [ ] GDPR deletion removes entity data (with retention for AML)
+
+---
+
+## 9. Implementation Steps
+
+### Phase 1: Entity Foundation (4-6 hours)
+1. Entity domain models and store
+2. Register/Get entity endpoints
+3. Basic validation
+4. Unit tests
+
+### Phase 2: Verification Integration (3-4 hours)
+1. Verification recording endpoint
+2. Sanctions status tracking
+3. Verification expiry logic
+
+### Phase 3: Representation Model (6-8 hours)
+1. Representation domain models and store
+2. Grant/Revoke/List endpoints
+3. Authorization hierarchy enforcement
+4. Constraint evaluation
+
+### Phase 4: Authorization Check (3-4 hours)
+1. Check endpoint with full context
+2. Integration with decision engine
+3. E2E tests
+
+---
+
+## 10. Future Enhancements
+
+- Company registry API integrations (Companies House, Handelsregister)
+- Beneficial ownership (UBO) tracking
+- Multi-level entity hierarchies (parent/subsidiary)
+- Representation approval workflows (pending → approved)
+- Document storage for evidence (board resolutions)
+- Cross-border entity recognition
+
+---
+
+## 11. References
+
+- [EU Company Law Directive](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32017L1132)
+- [5th Anti-Money Laundering Directive (5AMLD)](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32018L0843)
+- PRD-003: Registry Integration
+- PRD-035: Identity Assurance Levels
+
+---
+
+## Revision History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2025-12-22 | Engineering | Initial PRD |

--- a/docs/prd/PRD-037-Multi-Party-Authorization.md
+++ b/docs/prd/PRD-037-Multi-Party-Authorization.md
@@ -1,0 +1,740 @@
+# PRD-037: Multi-Party Authorization (Maker-Checker)
+
+**Status:** Not Started
+**Priority:** P1 (High - Banking/Fintech)
+**Owner:** Engineering Team
+**Dependencies:** PRD-036 (Legal Entity Identity), PRD-021 (MFA), PRD-027 (Adaptive Auth), PRD-006 (Audit)
+**Phase:** 8 (Banking Identity Pack)
+**Last Updated:** 2025-12-22
+
+---
+
+## 1. Overview
+
+### Problem Statement
+
+High-value or sensitive actions in banking require more than single-user approval. Regulations and corporate governance demand:
+- **Maker-Checker**: One person initiates, another approves
+- **Multi-Signature**: N of M approvers required (e.g., 2 of 3 directors)
+- **Hierarchical Approval**: Escalation based on amount or risk
+- **Time-Bound Approval**: Requests expire if not acted upon
+
+Current Credo supports single-user authentication and consent. For banking identity gateway use cases, we need **authorization requests** as a first-class primitive.
+
+### Goals
+
+- Model **authorization requests** with configurable approval rules
+- Support **maker-checker** (1 initiator + 1 approver)
+- Support **M-of-N approval** (2 of 3 directors)
+- Enforce **approval rules** based on entity/role (PRD-036)
+- Integrate with **SCA** (PRD-039) for approver authentication
+- Provide **non-repudiation** via signed approval records
+- Enable **policy-driven rules** (via PRD-015/PRD-027)
+
+### Non-Goals
+
+- Workflow orchestration beyond approval (no multi-step business processes)
+- Approval routing/assignment (who should approve is determined by rules, not UI)
+- Real-time collaboration/chat during approval
+- Approval delegation (covered in PRD-038)
+
+---
+
+## 2. User Stories
+
+**As a company CFO**
+**I want to** require two directors to approve transfers over €50,000
+**So that** we have proper financial controls
+
+**As a compliance officer**
+**I want to** see who approved each high-value transaction
+**So that** we have a clear audit trail for regulators
+
+**As a finance team member**
+**I want to** initiate a payment and have it queued for approval
+**So that** I can prepare payments in advance
+
+**As a director**
+**I want to** see pending approvals and approve from my mobile
+**So that** I don't block business operations
+
+**As an auditor**
+**I want to** verify the cryptographic proof of each approval
+**So that** I can confirm approvals weren't forged
+
+---
+
+## 3. Functional Requirements
+
+### FR-1: Authorization Request Model
+
+**Request Types:**
+
+| Type | Description | Default Rule |
+|------|-------------|--------------|
+| `transfer` | Payment/transfer approval | Amount-based thresholds |
+| `beneficiary_add` | New payment recipient | Maker-checker |
+| `card_create` | Issue new card | Maker-checker |
+| `card_limit_change` | Modify card limits | Amount-based |
+| `user_invite` | Add team member | Manager approval |
+| `settings_change` | Sensitive settings | Director approval |
+| `contract_sign` | Legal agreement | M-of-N directors |
+
+**Request Status:**
+
+```go
+type RequestStatus string
+
+const (
+    RequestStatusPending   RequestStatus = "pending"    // Awaiting approvals
+    RequestStatusApproved  RequestStatus = "approved"   // All approvals received
+    RequestStatusDenied    RequestStatus = "denied"     // Explicitly rejected
+    RequestStatusExpired   RequestStatus = "expired"    // Timeout without approval
+    RequestStatusCancelled RequestStatus = "cancelled"  // Initiator cancelled
+    RequestStatusExecuted  RequestStatus = "executed"   // Action completed
+)
+```
+
+### FR-2: Approval Rules
+
+**Rule Types:**
+
+```go
+type ApprovalRule struct {
+    ID          id.RuleID
+    EntityID    *id.EntityID       // Entity-specific or global
+    TenantID    id.TenantID
+    RequestType RequestType
+    Name        string
+    Conditions  []RuleCondition    // When rule applies
+    Requirement ApprovalRequirement
+    Priority    int                // Higher = evaluated first
+    Enabled     bool
+}
+
+type RuleCondition struct {
+    Field    string      // amount, currency, beneficiary_new, etc.
+    Operator string      // gt, gte, lt, lte, eq, in
+    Value    interface{} // 50000, "EUR", true, ["DE", "FR"]
+}
+
+type ApprovalRequirement struct {
+    Type       RequirementType  // any_of, all_of, m_of_n
+    Count      int              // For m_of_n: how many needed
+    Approvers  ApproverSpec     // Who can approve
+    TimeoutMin int              // Request expiry (minutes)
+}
+
+type ApproverSpec struct {
+    Roles       []RepresentationRole // director, signatory
+    Powers      []Power              // approve_transfers
+    UserIDs     []id.UserID          // Specific users (optional)
+    ExcludeInitiator bool            // Maker can't be checker
+}
+```
+
+**Example Rules:**
+
+```json
+[
+  {
+    "name": "Standard Transfer Approval",
+    "request_type": "transfer",
+    "conditions": [
+      {"field": "amount", "operator": "gte", "value": 10000},
+      {"field": "amount", "operator": "lt", "value": 50000}
+    ],
+    "requirement": {
+      "type": "any_of",
+      "count": 1,
+      "approvers": {
+        "powers": ["approve_transfers"],
+        "exclude_initiator": true
+      },
+      "timeout_min": 1440
+    }
+  },
+  {
+    "name": "High-Value Transfer Approval",
+    "request_type": "transfer",
+    "conditions": [
+      {"field": "amount", "operator": "gte", "value": 50000}
+    ],
+    "requirement": {
+      "type": "m_of_n",
+      "count": 2,
+      "approvers": {
+        "roles": ["director"],
+        "exclude_initiator": true
+      },
+      "timeout_min": 2880
+    }
+  },
+  {
+    "name": "New Beneficiary Approval",
+    "request_type": "beneficiary_add",
+    "conditions": [],
+    "requirement": {
+      "type": "any_of",
+      "count": 1,
+      "approvers": {
+        "powers": ["manage_beneficiaries"],
+        "exclude_initiator": true
+      },
+      "timeout_min": 4320
+    }
+  }
+]
+```
+
+### FR-3: Create Authorization Request
+
+**Endpoint:** `POST /authz/requests`
+
+**Description:** Initiate an action that requires approval.
+
+**Input:**
+
+```json
+{
+  "entity_id": "ent_abc123",
+  "request_type": "transfer",
+  "action_data": {
+    "amount": 75000,
+    "currency": "EUR",
+    "beneficiary_id": "ben_xyz789",
+    "beneficiary_name": "Supplier GmbH",
+    "reference": "INV-2025-001"
+  },
+  "urgency": "normal",
+  "notes": "Q4 invoice payment"
+}
+```
+
+**Output (Success - 201):**
+
+```json
+{
+  "request_id": "req_def456",
+  "entity_id": "ent_abc123",
+  "request_type": "transfer",
+  "status": "pending",
+  "initiated_by": "user_alice123",
+  "initiated_at": "2025-12-22T10:00:00Z",
+  "expires_at": "2025-12-24T10:00:00Z",
+  "approval_rule": {
+    "name": "High-Value Transfer Approval",
+    "type": "m_of_n",
+    "required_count": 2,
+    "approver_roles": ["director"]
+  },
+  "approvals": [],
+  "approvals_needed": 2
+}
+```
+
+**Business Logic:**
+
+1. Validate initiator has representation for entity
+2. Validate initiator has power to initiate this request type
+3. Find matching approval rule (highest priority match)
+4. If no rule matches, check if type requires approval (fail-safe)
+5. Create request with `pending` status
+6. Calculate expiry based on rule timeout
+7. Notify eligible approvers (via PRD-018)
+8. Emit audit event `authz.request_created`
+
+### FR-4: List Pending Requests
+
+**Endpoint:** `GET /authz/requests`
+
+**Query Parameters:**
+- `entity_id` - Filter by entity
+- `status` - pending, approved, denied, expired
+- `request_type` - transfer, beneficiary_add, etc.
+- `awaiting_my_approval` - Only requests user can approve
+
+**Output:**
+
+```json
+{
+  "requests": [
+    {
+      "request_id": "req_def456",
+      "request_type": "transfer",
+      "status": "pending",
+      "initiated_by": "Alice Smith",
+      "initiated_at": "2025-12-22T10:00:00Z",
+      "expires_at": "2025-12-24T10:00:00Z",
+      "summary": "Transfer €75,000 to Supplier GmbH",
+      "approvals_received": 1,
+      "approvals_needed": 2,
+      "can_approve": true
+    }
+  ],
+  "total": 1
+}
+```
+
+### FR-5: Submit Approval
+
+**Endpoint:** `POST /authz/requests/{request_id}/approve`
+
+**Description:** Approve a pending request. Requires SCA.
+
+**Input:**
+
+```json
+{
+  "decision": "approve",
+  "notes": "Verified against PO-2025-042",
+  "sca_token": "stepup_xyz789"
+}
+```
+
+**Output (Success - 200):**
+
+```json
+{
+  "request_id": "req_def456",
+  "status": "approved",
+  "approval": {
+    "approver_id": "user_bob456",
+    "approver_name": "Bob Jones",
+    "role": "director",
+    "decision": "approve",
+    "timestamp": "2025-12-22T11:30:00Z",
+    "signature": "eyJhbGciOiJFUzI1NiIs..."
+  },
+  "approvals_received": 2,
+  "approvals_needed": 2,
+  "final_status": "approved",
+  "ready_for_execution": true
+}
+```
+
+**Business Logic:**
+
+1. Validate request exists and is pending
+2. Validate request hasn't expired
+3. Validate approver has representation for entity
+4. Validate approver meets rule requirements (role/power)
+5. Validate approver isn't initiator (if exclude_initiator)
+6. Validate approver hasn't already approved
+7. Validate SCA token (PRD-039)
+8. Generate cryptographic signature for approval
+9. Store approval record
+10. Check if approval threshold met
+11. If met, update status to `approved`
+12. Emit audit event `authz.approval_submitted`
+13. Notify initiator of status change
+
+### FR-6: Deny Request
+
+**Endpoint:** `POST /authz/requests/{request_id}/deny`
+
+**Input:**
+
+```json
+{
+  "reason": "Beneficiary not in approved vendor list",
+  "sca_token": "stepup_xyz789"
+}
+```
+
+**Business Logic:**
+
+1. Validate denier has approval authority
+2. Set status to `denied`
+3. Record reason and denier
+4. Emit audit event `authz.request_denied`
+5. Notify initiator
+
+**Note:** Single denial by any eligible approver denies the entire request.
+
+### FR-7: Cancel Request
+
+**Endpoint:** `POST /authz/requests/{request_id}/cancel`
+
+**Description:** Initiator cancels their own request.
+
+**Input:**
+
+```json
+{
+  "reason": "No longer needed - duplicate payment"
+}
+```
+
+### FR-8: Execute Approved Request
+
+**Endpoint:** `POST /authz/requests/{request_id}/execute`
+
+**Description:** Mark request as executed after downstream action completes.
+
+**Input:**
+
+```json
+{
+  "execution_reference": "txn_abc123",
+  "executed_at": "2025-12-22T12:00:00Z"
+}
+```
+
+**Note:** This is called by the system after the actual action (e.g., payment) is performed. The authorization request tracks approval; execution is recorded for audit completeness.
+
+### FR-9: Non-Repudiation Signatures
+
+Each approval is cryptographically signed:
+
+```go
+type ApprovalSignature struct {
+    RequestID    id.RequestID
+    ApproverID   id.UserID
+    Decision     string        // approve, deny
+    Timestamp    time.Time
+    ActionDigest string        // SHA-256 of action_data
+    Signature    string        // ECDSA signature
+    PublicKeyRef string        // Key identifier for verification
+}
+```
+
+**Signature Payload:**
+
+```json
+{
+  "request_id": "req_def456",
+  "approver_id": "user_bob456",
+  "decision": "approve",
+  "timestamp": "2025-12-22T11:30:00Z",
+  "action_digest": "sha256:abc123..."
+}
+```
+
+---
+
+## 4. Technical Requirements
+
+### TR-1: Data Models
+
+```go
+// internal/authz/models.go
+
+type AuthorizationRequest struct {
+    ID            id.RequestID
+    EntityID      id.EntityID
+    TenantID      id.TenantID
+    RequestType   RequestType
+    Status        RequestStatus
+    InitiatedBy   id.UserID
+    InitiatedAt   time.Time
+    ExpiresAt     time.Time
+    ActionData    map[string]interface{}  // Type-specific payload
+    ActionDigest  string                  // SHA-256 for signature verification
+    ApprovalRule  *ApprovalRule           // Snapshot of rule at creation
+    Urgency       Urgency
+    Notes         *string
+    Approvals     []Approval
+    DeniedBy      *id.UserID
+    DeniedAt      *time.Time
+    DeniedReason  *string
+    CancelledBy   *id.UserID
+    CancelledAt   *time.Time
+    CancelledReason *string
+    ExecutedAt    *time.Time
+    ExecutionRef  *string
+    CreatedAt     time.Time
+    UpdatedAt     time.Time
+}
+
+type Approval struct {
+    ID           id.ApprovalID
+    RequestID    id.RequestID
+    ApproverID   id.UserID
+    Role         RepresentationRole
+    Decision     ApprovalDecision  // approve, deny
+    Notes        *string
+    Timestamp    time.Time
+    SCAMethod    string            // totp, passkey, paired_device
+    Signature    string            // ECDSA signature
+    PublicKeyRef string
+}
+
+func (r *AuthorizationRequest) ApprovalsNeeded() int {
+    if r.ApprovalRule == nil {
+        return 1
+    }
+    return r.ApprovalRule.Requirement.Count
+}
+
+func (r *AuthorizationRequest) ApprovalsReceived() int {
+    count := 0
+    for _, a := range r.Approvals {
+        if a.Decision == ApprovalDecisionApprove {
+            count++
+        }
+    }
+    return count
+}
+
+func (r *AuthorizationRequest) IsFullyApproved() bool {
+    return r.ApprovalsReceived() >= r.ApprovalsNeeded()
+}
+
+func (r *AuthorizationRequest) IsExpired() bool {
+    return time.Now().After(r.ExpiresAt)
+}
+```
+
+### TR-2: Store Interfaces
+
+```go
+type AuthorizationRequestStore interface {
+    Save(ctx context.Context, req *AuthorizationRequest) error
+    FindByID(ctx context.Context, id id.RequestID) (*AuthorizationRequest, error)
+    FindByEntity(ctx context.Context, entityID id.EntityID, filter RequestFilter) ([]AuthorizationRequest, error)
+    FindPendingForApprover(ctx context.Context, userID id.UserID, entityID *id.EntityID) ([]AuthorizationRequest, error)
+    Update(ctx context.Context, req *AuthorizationRequest) error
+    AddApproval(ctx context.Context, approval *Approval) error
+    ExpirePending(ctx context.Context) (int, error)  // Background job
+}
+
+type ApprovalRuleStore interface {
+    Save(ctx context.Context, rule *ApprovalRule) error
+    FindByID(ctx context.Context, id id.RuleID) (*ApprovalRule, error)
+    FindByEntityAndType(ctx context.Context, entityID id.EntityID, reqType RequestType) ([]ApprovalRule, error)
+    FindGlobalByType(ctx context.Context, tenantID id.TenantID, reqType RequestType) ([]ApprovalRule, error)
+    Update(ctx context.Context, rule *ApprovalRule) error
+    Delete(ctx context.Context, id id.RuleID) error
+}
+```
+
+### TR-3: Service Layer
+
+```go
+type AuthorizationService struct {
+    requests       AuthorizationRequestStore
+    rules          ApprovalRuleStore
+    representations RepresentationStore  // PRD-036
+    sca            SCAService            // PRD-039
+    notifications  NotificationService   // PRD-018
+    signer         ApprovalSigner
+    auditor        audit.Publisher
+}
+
+func (s *AuthorizationService) CreateRequest(ctx context.Context, req CreateRequestInput) (*AuthorizationRequest, error)
+func (s *AuthorizationService) ListRequests(ctx context.Context, filter RequestFilter) ([]AuthorizationRequest, error)
+func (s *AuthorizationService) GetRequest(ctx context.Context, id id.RequestID) (*AuthorizationRequest, error)
+func (s *AuthorizationService) SubmitApproval(ctx context.Context, req SubmitApprovalInput) (*AuthorizationRequest, error)
+func (s *AuthorizationService) DenyRequest(ctx context.Context, req DenyRequestInput) (*AuthorizationRequest, error)
+func (s *AuthorizationService) CancelRequest(ctx context.Context, id id.RequestID, reason string) error
+func (s *AuthorizationService) MarkExecuted(ctx context.Context, id id.RequestID, ref string) error
+
+// Rule management
+func (s *AuthorizationService) CreateRule(ctx context.Context, rule *ApprovalRule) error
+func (s *AuthorizationService) UpdateRule(ctx context.Context, rule *ApprovalRule) error
+func (s *AuthorizationService) DeleteRule(ctx context.Context, id id.RuleID) error
+func (s *AuthorizationService) EvaluateRules(ctx context.Context, entityID id.EntityID, reqType RequestType, actionData map[string]interface{}) (*ApprovalRule, error)
+```
+
+### TR-4: Background Jobs
+
+```go
+// Expire pending requests
+func (s *AuthorizationService) ExpirePendingRequests(ctx context.Context) error {
+    count, err := s.requests.ExpirePending(ctx)
+    if err != nil {
+        return err
+    }
+    if count > 0 {
+        s.auditor.Emit(ctx, audit.Event{
+            Action: "authz.requests_expired",
+            Metadata: map[string]interface{}{"count": count},
+        })
+    }
+    return nil
+}
+
+// Send reminders for pending requests approaching expiry
+func (s *AuthorizationService) SendExpiryReminders(ctx context.Context) error
+```
+
+### TR-5: Approval Signing
+
+```go
+type ApprovalSigner interface {
+    Sign(ctx context.Context, payload ApprovalPayload) (signature string, keyRef string, error)
+    Verify(ctx context.Context, payload ApprovalPayload, signature string, keyRef string) (bool, error)
+}
+
+type ApprovalPayload struct {
+    RequestID    id.RequestID
+    ApproverID   id.UserID
+    Decision     string
+    Timestamp    time.Time
+    ActionDigest string
+}
+
+// Implementation using ECDSA P-256
+type ECDSASigner struct {
+    keyStore KeyStore
+}
+```
+
+---
+
+## 5. API Specifications
+
+| Endpoint | Method | Auth | Purpose |
+|----------|--------|------|---------|
+| `/authz/requests` | POST | Bearer | Create authorization request |
+| `/authz/requests` | GET | Bearer | List requests (with filters) |
+| `/authz/requests/{id}` | GET | Bearer | Get request details |
+| `/authz/requests/{id}/approve` | POST | Bearer+SCA | Submit approval |
+| `/authz/requests/{id}/deny` | POST | Bearer+SCA | Deny request |
+| `/authz/requests/{id}/cancel` | POST | Bearer | Cancel own request |
+| `/authz/requests/{id}/execute` | POST | Service | Mark as executed |
+| `/authz/rules` | GET | Admin | List approval rules |
+| `/authz/rules` | POST | Admin | Create rule |
+| `/authz/rules/{id}` | PUT | Admin | Update rule |
+| `/authz/rules/{id}` | DELETE | Admin | Delete rule |
+
+---
+
+## 6. Security Requirements
+
+### SR-1: Authorization Checks
+- Initiator must have representation + initiation power
+- Approvers must have representation + approval power
+- Initiator cannot approve own request (configurable)
+- All approvals require valid SCA
+
+### SR-2: Non-Repudiation
+- All approvals cryptographically signed
+- Signatures verifiable offline
+- Action data hashed and included in signature
+
+### SR-3: Request Integrity
+- Action data immutable after creation
+- Rule snapshot stored with request (rule changes don't affect pending)
+- Status transitions validated (no skipping states)
+
+### SR-4: Time Sensitivity
+- Requests expire per rule configuration
+- Expired requests cannot be approved
+- Clock skew tolerance: 30 seconds
+
+---
+
+## 7. Observability
+
+### Metrics
+
+```
+# Counter: Requests created by type
+authz_requests_created_total{entity_id, request_type}
+
+# Counter: Request outcomes
+authz_requests_completed_total{request_type, outcome="approved|denied|expired|cancelled"}
+
+# Histogram: Time to approval
+authz_approval_duration_seconds{request_type}
+
+# Gauge: Pending requests
+authz_requests_pending{entity_id, request_type}
+
+# Counter: Approvals submitted
+authz_approvals_submitted_total{decision="approve|deny"}
+```
+
+### Audit Events
+
+- `authz.request_created` - New request initiated
+- `authz.approval_submitted` - Approval/denial recorded
+- `authz.request_approved` - Request fully approved
+- `authz.request_denied` - Request denied
+- `authz.request_expired` - Request auto-expired
+- `authz.request_cancelled` - Request cancelled by initiator
+- `authz.request_executed` - Downstream action completed
+- `authz.rule_created` - New approval rule
+- `authz.rule_updated` - Rule modified
+- `authz.rule_deleted` - Rule removed
+
+---
+
+## 8. Acceptance Criteria
+
+- [ ] Authorization requests can be created for defined types
+- [ ] Approval rules evaluated based on conditions (amount, type)
+- [ ] M-of-N approval logic works correctly
+- [ ] Initiator exclusion enforced when configured
+- [ ] SCA required for all approval actions
+- [ ] Cryptographic signatures generated and verifiable
+- [ ] Requests expire after timeout
+- [ ] Notifications sent to eligible approvers
+- [ ] Audit trail complete for all state changes
+- [ ] Admin can configure approval rules per entity
+
+---
+
+## 9. Implementation Steps
+
+### Phase 1: Foundation (6-8 hours)
+1. Domain models for requests, approvals, rules
+2. Store implementations
+3. Basic create/get/list endpoints
+4. Unit tests
+
+### Phase 2: Approval Logic (4-6 hours)
+1. Rule evaluation engine
+2. Approval submission with validation
+3. M-of-N threshold logic
+4. Status transitions
+
+### Phase 3: Security Layer (4-6 hours)
+1. SCA integration (PRD-039)
+2. Approval signing
+3. Signature verification endpoint
+4. Initiator exclusion logic
+
+### Phase 4: Notifications & Jobs (3-4 hours)
+1. Approver notification on request creation
+2. Status change notifications
+3. Expiry background job
+4. Reminder job
+
+### Phase 5: Admin & Rules (3-4 hours)
+1. Rule CRUD endpoints
+2. Rule condition evaluation
+3. Per-entity rule configuration
+4. E2E tests
+
+---
+
+## 10. Future Enhancements
+
+- Approval escalation (auto-escalate if no response)
+- Conditional approval (approve with modifications)
+- Approval templates (pre-configured rule sets)
+- Batch approval (approve multiple requests)
+- Approval analytics dashboard
+- Mobile push notifications for approvals
+- Integration with external approval systems
+
+---
+
+## 11. References
+
+- [PSD2 Strong Customer Authentication](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32018R0389)
+- [ISO 20022 Payment Standards](https://www.iso20022.org/)
+- PRD-036: Legal Entity Identity
+- PRD-039: SCA Orchestration
+- PRD-021: Multi-Factor Authentication
+
+---
+
+## Revision History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2025-12-22 | Engineering | Initial PRD |

--- a/docs/prd/PRD-038-Delegated-Authority.md
+++ b/docs/prd/PRD-038-Delegated-Authority.md
@@ -1,0 +1,682 @@
+# PRD-038: Delegated Authority (Power of Attorney)
+
+**Status:** Not Started
+**Priority:** P1 (High - Banking/Fintech)
+**Owner:** Engineering Team
+**Dependencies:** PRD-036 (Legal Entity Identity), PRD-037 (Multi-Party Auth), PRD-021 (MFA), PRD-006 (Audit)
+**Phase:** 8 (Banking Identity Pack)
+**Last Updated:** 2025-12-22
+
+---
+
+## 1. Overview
+
+### Problem Statement
+
+Real-world banking involves people acting on behalf of others:
+- **Vacation coverage**: "While I'm away, my colleague can approve up to €5,000"
+- **Accountant access**: "My accountant can view transactions but not transfer"
+- **Spouse/family**: "My partner can manage our joint account expenses"
+- **Legal guardianship**: "I manage finances for my elderly parent"
+- **Corporate proxy**: "I'm authorized to act for the CEO during Q4"
+
+PRD-036 covers **entity → user representation** (who can act for a company). This PRD covers **user → user delegation** (one person granting authority to another person).
+
+### Goals
+
+- Model **delegations** as user-to-user authority grants
+- Support **scoped powers** (what the delegate can do)
+- Support **constraints** (amount limits, time bounds, specific resources)
+- Require **grantor consent** for delegation creation
+- Enable **revocation** at any time by grantor
+- Integrate with authorization checks (PRD-037)
+- Provide **audit trail** for all delegated actions
+
+### Non-Goals
+
+- Cascading delegation (delegate cannot re-delegate)
+- Legal power of attorney document generation
+- Court-appointed guardianship verification
+- Delegation marketplaces or discovery
+
+---
+
+## 2. User Stories
+
+**As a business owner**
+**I want to** grant my accountant authority to view transactions and initiate small payments
+**So that** they can manage day-to-day finances while I focus on the business
+
+**As a senior employee**
+**I want to** delegate my approval authority to a colleague while on vacation
+**So that** business operations aren't blocked by my absence
+
+**As a delegate**
+**I want to** see clearly what actions I can take on someone's behalf
+**So that** I don't accidentally exceed my authority
+
+**As a grantor**
+**I want to** revoke delegation immediately if needed
+**So that** I maintain control over my authority
+
+**As a compliance officer**
+**I want to** see when actions were taken under delegation
+**So that** I can distinguish delegated from direct actions in audits
+
+---
+
+## 3. Functional Requirements
+
+### FR-1: Delegation Model
+
+**Delegation** grants a grantee (delegate) authority to act on behalf of a grantor within defined scope.
+
+```go
+type Delegation struct {
+    ID            id.DelegationID
+    TenantID      id.TenantID
+    GrantorID     id.UserID         // Who grants authority
+    GranteeID     id.UserID         // Who receives authority
+    EntityID      *id.EntityID      // Optional: scope to specific entity
+    Scope         DelegationScope
+    Constraints   *DelegationConstraints
+    Status        DelegationStatus  // active, suspended, revoked, expired
+    RequiresSCA   bool              // Delegate must SCA for actions
+    ValidFrom     time.Time
+    ValidUntil    *time.Time
+    CreatedAt     time.Time
+    RevokedAt     *time.Time
+    RevokedBy     *id.UserID
+    RevokedReason *string
+}
+
+type DelegationScope struct {
+    Powers        []Power           // What can they do
+    ResourceTypes []string          // Optional: specific resource types
+    ResourceIDs   []string          // Optional: specific resource IDs
+}
+
+type DelegationConstraints struct {
+    AmountLimit   *AmountLimit      // Max per transaction/day/month
+    TimeWindow    *TimeWindow       // e.g., business hours only
+    RequiresNote  bool              // Must provide reason for each action
+    MaxActions    *int              // Total action limit
+}
+```
+
+### FR-2: Create Delegation
+
+**Endpoint:** `POST /delegations`
+
+**Description:** Grant authority to another user.
+
+**Input:**
+
+```json
+{
+  "grantee_id": "user_bob456",
+  "entity_id": "ent_abc123",
+  "scope": {
+    "powers": ["view_transactions", "initiate_transfers"],
+    "resource_types": ["bank_account"]
+  },
+  "constraints": {
+    "amount_limit": {
+      "max_single": 5000,
+      "max_daily": 10000,
+      "currency": "EUR"
+    },
+    "time_window": {
+      "days": ["monday", "tuesday", "wednesday", "thursday", "friday"],
+      "start_hour": 9,
+      "end_hour": 18,
+      "timezone": "Europe/Berlin"
+    }
+  },
+  "requires_sca": true,
+  "valid_from": "2025-12-23T00:00:00Z",
+  "valid_until": "2026-01-07T00:00:00Z",
+  "notes": "Vacation coverage - Bob can handle small payments"
+}
+```
+
+**Output (Success - 201):**
+
+```json
+{
+  "delegation_id": "del_xyz789",
+  "grantor_id": "user_alice123",
+  "grantee_id": "user_bob456",
+  "entity_id": "ent_abc123",
+  "status": "active",
+  "scope": {
+    "powers": ["view_transactions", "initiate_transfers"]
+  },
+  "constraints": {
+    "amount_limit": {
+      "max_single": 5000,
+      "max_daily": 10000,
+      "currency": "EUR"
+    }
+  },
+  "valid_from": "2025-12-23T00:00:00Z",
+  "valid_until": "2026-01-07T00:00:00Z",
+  "created_at": "2025-12-22T10:00:00Z"
+}
+```
+
+**Business Logic:**
+
+1. Validate grantor is authenticated user
+2. Validate grantee exists and is active
+3. Validate grantor has the powers they're delegating
+4. Validate grantor can delegate (has `can_delegate` flag or power)
+5. If entity_id provided, validate grantor has representation
+6. Check for conflicting delegations
+7. Create delegation with `active` status
+8. Emit audit event `delegation.created`
+9. Notify grantee of new delegation
+
+### FR-3: List Delegations
+
+**Endpoint:** `GET /delegations`
+
+**Query Parameters:**
+- `as` - "grantor" or "grantee" (required)
+- `status` - active, expired, revoked
+- `entity_id` - Filter by entity
+
+**Output (as grantor):**
+
+```json
+{
+  "delegations": [
+    {
+      "delegation_id": "del_xyz789",
+      "grantee_id": "user_bob456",
+      "grantee_name": "Bob Jones",
+      "entity_id": "ent_abc123",
+      "entity_name": "Acme GmbH",
+      "status": "active",
+      "powers": ["view_transactions", "initiate_transfers"],
+      "valid_until": "2026-01-07T00:00:00Z",
+      "can_revoke": true
+    }
+  ],
+  "total": 1
+}
+```
+
+**Output (as grantee):**
+
+```json
+{
+  "delegations": [
+    {
+      "delegation_id": "del_xyz789",
+      "grantor_id": "user_alice123",
+      "grantor_name": "Alice Smith",
+      "entity_id": "ent_abc123",
+      "entity_name": "Acme GmbH",
+      "status": "active",
+      "powers": ["view_transactions", "initiate_transfers"],
+      "constraints": {
+        "amount_limit": {"max_single": 5000, "currency": "EUR"}
+      },
+      "valid_until": "2026-01-07T00:00:00Z"
+    }
+  ],
+  "total": 1
+}
+```
+
+### FR-4: Check Delegation Authority
+
+**Endpoint:** `POST /delegations/check`
+
+**Description:** Check if a user can act on behalf of another user.
+
+**Input:**
+
+```json
+{
+  "grantee_id": "user_bob456",
+  "grantor_id": "user_alice123",
+  "entity_id": "ent_abc123",
+  "power": "initiate_transfers",
+  "context": {
+    "amount": 3000,
+    "currency": "EUR",
+    "action_time": "2025-12-26T14:30:00Z"
+  }
+}
+```
+
+**Output (Allowed):**
+
+```json
+{
+  "allowed": true,
+  "delegation_id": "del_xyz789",
+  "acting_as": {
+    "grantor_id": "user_alice123",
+    "grantor_name": "Alice Smith"
+  },
+  "constraints_evaluated": {
+    "amount_within_limit": true,
+    "time_within_window": true
+  }
+}
+```
+
+**Output (Denied):**
+
+```json
+{
+  "allowed": false,
+  "reason": "amount_exceeds_limit",
+  "delegation_id": "del_xyz789",
+  "constraint_violated": {
+    "type": "amount_limit",
+    "limit": 5000,
+    "requested": 7500,
+    "currency": "EUR"
+  }
+}
+```
+
+### FR-5: Revoke Delegation
+
+**Endpoint:** `POST /delegations/{id}/revoke`
+
+**Description:** Grantor revokes delegation immediately.
+
+**Input:**
+
+```json
+{
+  "reason": "No longer needed - returned from vacation"
+}
+```
+
+**Output (Success - 200):**
+
+```json
+{
+  "delegation_id": "del_xyz789",
+  "status": "revoked",
+  "revoked_at": "2025-12-22T16:00:00Z",
+  "revoked_by": "user_alice123"
+}
+```
+
+**Business Logic:**
+
+1. Validate requester is grantor (or admin)
+2. Validate delegation is active
+3. Set status to `revoked`
+4. Record revocation timestamp and reason
+5. Emit audit event `delegation.revoked`
+6. Notify grantee
+
+### FR-6: Acting Under Delegation
+
+When a user acts under delegation, the system must:
+
+1. **Identify the delegation** - User specifies or system infers
+2. **Validate the delegation** - Check status, expiry, constraints
+3. **Require SCA if configured** - Step-up auth for delegate
+4. **Execute action** - With grantor's authority
+5. **Record the delegation** - Audit trail shows delegated action
+
+**Request Header:**
+
+```
+X-Acting-As: user_alice123
+X-Delegation-ID: del_xyz789
+```
+
+**Audit Event:**
+
+```json
+{
+  "event": "transfer.initiated",
+  "actor_id": "user_bob456",
+  "acting_as": "user_alice123",
+  "delegation_id": "del_xyz789",
+  "entity_id": "ent_abc123",
+  "action_data": {
+    "amount": 3000,
+    "currency": "EUR"
+  },
+  "timestamp": "2025-12-26T14:30:00Z"
+}
+```
+
+### FR-7: Delegation Notifications
+
+| Event | Notify |
+|-------|--------|
+| Delegation created | Grantee |
+| Delegation revoked | Grantee |
+| Delegation expiring (24h) | Grantor, Grantee |
+| Delegation expired | Grantor, Grantee |
+| Action under delegation | Grantor (configurable) |
+
+---
+
+## 4. Technical Requirements
+
+### TR-1: Data Models
+
+```go
+// internal/delegation/models.go
+
+type Delegation struct {
+    ID            id.DelegationID
+    TenantID      id.TenantID
+    GrantorID     id.UserID
+    GranteeID     id.UserID
+    EntityID      *id.EntityID
+    Scope         DelegationScope
+    Constraints   *DelegationConstraints
+    Status        DelegationStatus
+    RequiresSCA   bool
+    NotifyGrantor bool              // Notify on each delegated action
+    ValidFrom     time.Time
+    ValidUntil    *time.Time
+    ActionsCount  int               // Track usage
+    CreatedAt     time.Time
+    RevokedAt     *time.Time
+    RevokedBy     *id.UserID
+    RevokedReason *string
+}
+
+type DelegationStatus string
+
+const (
+    DelegationStatusPending   DelegationStatus = "pending"   // Awaiting grantee acceptance
+    DelegationStatusActive    DelegationStatus = "active"
+    DelegationStatusSuspended DelegationStatus = "suspended"
+    DelegationStatusRevoked   DelegationStatus = "revoked"
+    DelegationStatusExpired   DelegationStatus = "expired"
+)
+
+type DelegationScope struct {
+    Powers        []Power
+    ResourceTypes []string
+    ResourceIDs   []string
+}
+
+type DelegationConstraints struct {
+    AmountLimit   *AmountLimit
+    TimeWindow    *TimeWindow
+    RequiresNote  bool
+    MaxActions    *int
+}
+
+type AmountLimit struct {
+    MaxSingle   int64
+    MaxDaily    int64
+    MaxMonthly  int64
+    Currency    string
+    UsedToday   int64   // Tracked for daily limit
+    UsedMonth   int64   // Tracked for monthly limit
+}
+
+type TimeWindow struct {
+    Days      []string  // monday, tuesday, etc.
+    StartHour int       // 0-23
+    EndHour   int       // 0-23
+    Timezone  string    // IANA timezone
+}
+
+func (d *Delegation) IsValid(now time.Time) bool {
+    if d.Status != DelegationStatusActive {
+        return false
+    }
+    if now.Before(d.ValidFrom) {
+        return false
+    }
+    if d.ValidUntil != nil && now.After(*d.ValidUntil) {
+        return false
+    }
+    return true
+}
+
+func (d *Delegation) CheckConstraints(ctx CheckContext) error {
+    if d.Constraints == nil {
+        return nil
+    }
+
+    if d.Constraints.AmountLimit != nil {
+        if ctx.Amount > d.Constraints.AmountLimit.MaxSingle {
+            return ErrAmountExceedsLimit
+        }
+        // Check daily/monthly limits...
+    }
+
+    if d.Constraints.TimeWindow != nil {
+        if !d.Constraints.TimeWindow.Contains(ctx.ActionTime) {
+            return ErrOutsideTimeWindow
+        }
+    }
+
+    if d.Constraints.MaxActions != nil {
+        if d.ActionsCount >= *d.Constraints.MaxActions {
+            return ErrMaxActionsReached
+        }
+    }
+
+    return nil
+}
+```
+
+### TR-2: Store Interface
+
+```go
+type DelegationStore interface {
+    Save(ctx context.Context, delegation *Delegation) error
+    FindByID(ctx context.Context, id id.DelegationID) (*Delegation, error)
+    FindByGrantor(ctx context.Context, grantorID id.UserID, filter DelegationFilter) ([]Delegation, error)
+    FindByGrantee(ctx context.Context, granteeID id.UserID, filter DelegationFilter) ([]Delegation, error)
+    FindActiveByGrantorAndGrantee(ctx context.Context, grantorID, granteeID id.UserID, entityID *id.EntityID) (*Delegation, error)
+    Update(ctx context.Context, delegation *Delegation) error
+    IncrementActionCount(ctx context.Context, id id.DelegationID) error
+    ExpireAll(ctx context.Context) (int, error)  // Background job
+}
+```
+
+### TR-3: Service Layer
+
+```go
+type DelegationService struct {
+    delegations     DelegationStore
+    users           UserStore
+    representations RepresentationStore  // PRD-036
+    notifications   NotificationService  // PRD-018
+    auditor         audit.Publisher
+}
+
+func (s *DelegationService) CreateDelegation(ctx context.Context, req CreateDelegationRequest) (*Delegation, error)
+func (s *DelegationService) ListDelegations(ctx context.Context, userID id.UserID, role string, filter DelegationFilter) ([]Delegation, error)
+func (s *DelegationService) GetDelegation(ctx context.Context, id id.DelegationID) (*Delegation, error)
+func (s *DelegationService) CheckAuthority(ctx context.Context, req CheckAuthorityRequest) (*CheckResult, error)
+func (s *DelegationService) RevokeDelegation(ctx context.Context, id id.DelegationID, revokerID id.UserID, reason string) error
+func (s *DelegationService) RecordAction(ctx context.Context, delegationID id.DelegationID, action ActionRecord) error
+```
+
+### TR-4: Middleware for Delegated Actions
+
+```go
+func DelegationMiddleware(delegationSvc *DelegationService) func(http.Handler) http.Handler {
+    return func(next http.Handler) http.Handler {
+        return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+            actingAs := r.Header.Get("X-Acting-As")
+            delegationID := r.Header.Get("X-Delegation-ID")
+
+            if actingAs == "" {
+                // Normal request, no delegation
+                next.ServeHTTP(w, r)
+                return
+            }
+
+            // Validate delegation
+            result, err := delegationSvc.CheckAuthority(r.Context(), CheckAuthorityRequest{
+                GranteeID:    getCurrentUserID(r.Context()),
+                GrantorID:    actingAs,
+                DelegationID: delegationID,
+                Power:        getRequiredPower(r),
+            })
+            if err != nil || !result.Allowed {
+                http.Error(w, "Delegation not valid", http.StatusForbidden)
+                return
+            }
+
+            // Add delegation context
+            ctx := context.WithValue(r.Context(), delegationKey, result.Delegation)
+            ctx = context.WithValue(ctx, actingAsKey, actingAs)
+
+            next.ServeHTTP(w, r.WithContext(ctx))
+        })
+    }
+}
+```
+
+---
+
+## 5. API Specifications
+
+| Endpoint | Method | Auth | Purpose |
+|----------|--------|------|---------|
+| `/delegations` | POST | Bearer | Create delegation |
+| `/delegations` | GET | Bearer | List delegations |
+| `/delegations/{id}` | GET | Bearer | Get delegation details |
+| `/delegations/{id}/revoke` | POST | Bearer | Revoke delegation |
+| `/delegations/check` | POST | Service | Check delegation authority |
+| `/delegations/{id}/actions` | GET | Bearer | List actions under delegation |
+
+---
+
+## 6. Security Requirements
+
+### SR-1: Authority Verification
+- Grantor must possess the powers being delegated
+- Delegation cannot exceed grantor's own authority
+- Entity-scoped delegations require grantor representation
+
+### SR-2: Delegation Limits
+- Maximum delegation depth: 1 (no sub-delegation)
+- Maximum active delegations per grantor: configurable (default 10)
+- Maximum delegation duration: configurable (default 90 days)
+
+### SR-3: Revocation
+- Grantor can revoke any time
+- Revocation is immediate
+- In-flight actions may complete, but new actions blocked
+
+### SR-4: Audit
+- All delegated actions clearly marked in audit
+- Grantor can see all actions taken under their delegation
+- Delegation lifecycle fully audited
+
+---
+
+## 7. Observability
+
+### Metrics
+
+```
+# Gauge: Active delegations
+delegations_active{tenant_id}
+
+# Counter: Delegations created/revoked
+delegations_lifecycle_total{action="created|revoked|expired"}
+
+# Counter: Actions under delegation
+delegated_actions_total{power, result="allowed|denied"}
+
+# Histogram: Delegation duration
+delegation_duration_days
+```
+
+### Audit Events
+
+- `delegation.created` - New delegation granted
+- `delegation.accepted` - Grantee accepted (if acceptance required)
+- `delegation.revoked` - Delegation revoked
+- `delegation.expired` - Delegation auto-expired
+- `delegation.action_performed` - Action taken under delegation
+- `delegation.action_denied` - Delegated action denied (constraint violation)
+
+---
+
+## 8. Acceptance Criteria
+
+- [ ] Users can create delegations with scoped powers
+- [ ] Delegations enforce time validity (from/until)
+- [ ] Amount constraints enforced per transaction/day/month
+- [ ] Time window constraints enforced
+- [ ] Grantor can revoke delegation immediately
+- [ ] Delegated actions recorded with delegation context
+- [ ] Grantee notified of new/revoked delegations
+- [ ] Audit trail distinguishes delegated from direct actions
+- [ ] API check endpoint validates delegation authority
+- [ ] Middleware enforces delegation for X-Acting-As requests
+
+---
+
+## 9. Implementation Steps
+
+### Phase 1: Foundation (4-6 hours)
+1. Delegation domain models
+2. Store implementation
+3. Create/Get/List endpoints
+4. Unit tests
+
+### Phase 2: Authority Checks (3-4 hours)
+1. Check endpoint implementation
+2. Constraint evaluation logic
+3. Grantor authority validation
+
+### Phase 3: Middleware & Integration (3-4 hours)
+1. X-Acting-As header handling
+2. Delegation middleware
+3. Audit context propagation
+
+### Phase 4: Lifecycle (2-3 hours)
+1. Revocation flow
+2. Expiry background job
+3. Notifications
+
+### Phase 5: Observability (2 hours)
+1. Metrics
+2. Audit events
+3. E2E tests
+
+---
+
+## 10. Future Enhancements
+
+- Delegation acceptance workflow (grantee must accept)
+- Delegation templates (pre-defined scope/constraint sets)
+- Delegation requests (grantee can request authority)
+- Emergency delegation (bypass normal flows in crisis)
+- Delegation analytics (usage patterns, underutilized delegations)
+- Multi-level delegation with explicit approval
+
+---
+
+## 11. References
+
+- [Power of Attorney - Legal Framework](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:62016CJ0218)
+- PRD-036: Legal Entity Identity
+- PRD-037: Multi-Party Authorization
+
+---
+
+## Revision History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2025-12-22 | Engineering | Initial PRD |

--- a/docs/prd/PRD-039-SCA-Orchestration.md
+++ b/docs/prd/PRD-039-SCA-Orchestration.md
@@ -1,0 +1,731 @@
+# PRD-039: SCA Orchestration (PSD2 Strong Customer Authentication)
+
+**Status:** Not Started
+**Priority:** P0 (Critical - Banking/Fintech Compliance)
+**Owner:** Engineering Team
+**Dependencies:** PRD-001 (Authentication), PRD-021 (MFA), PRD-027 (Adaptive Auth), PRD-018 (Notifications)
+**Phase:** 8 (Banking Identity Pack)
+**Last Updated:** 2025-12-22
+
+---
+
+## 1. Overview
+
+### Problem Statement
+
+PSD2 (Payment Services Directive 2) requires **Strong Customer Authentication (SCA)** for:
+- Payment initiation
+- Account access (with exemptions)
+- Sensitive data changes
+
+SCA requires 2 of 3 authentication factors:
+- **Knowledge**: Something the user knows (password, PIN)
+- **Possession**: Something the user has (phone, hardware token)
+- **Inherence**: Something the user is (biometric)
+
+Current Credo has MFA (PRD-021) but lacks:
+- Action-specific SCA challenges
+- Session tokens bound to specific operations
+- SCA exemption management
+- PSD2-compliant challenge flows
+
+This is the **exact flow Qonto's API uses** — a 428 response triggers SCA, the user approves on their device, and the request is retried with an `sca_session_token`.
+
+### Goals
+
+- Implement **action-bound SCA challenges** (not reusable across actions)
+- Support **multiple SCA methods** (paired device, passkey, SMS OTP fallback)
+- Manage **SCA exemptions** (low value, trusted beneficiary, recurring)
+- Provide **session tokens** for approved SCA challenges
+- Enable **policy-driven SCA triggers** (amount, action type, risk)
+- Ensure **PSD2/RTS compliance** for payment service providers
+
+### Non-Goals
+
+- Implementing the payment execution itself
+- Biometric hardware integration (use device capabilities)
+- SCA for card-present transactions (3DS is separate)
+- Cross-border SCA interoperability
+
+---
+
+## 2. User Stories
+
+**As a fintech API consumer**
+**I want to** receive a 428 response when SCA is required
+**So that** I can prompt the user for authentication and retry
+
+**As a mobile app user**
+**I want to** approve transactions via push notification on my paired device
+**So that** I don't need to leave the banking app
+
+**As a frequent user**
+**I want to** skip SCA for small payments to trusted beneficiaries
+**So that** everyday transactions are frictionless
+
+**As a compliance officer**
+**I want to** configure SCA thresholds per transaction type
+**So that** we meet PSD2 requirements while optimizing UX
+
+**As a security engineer**
+**I want to** ensure SCA tokens are bound to specific actions
+**So that** a token can't be reused for different transactions
+
+---
+
+## 3. Functional Requirements
+
+### FR-1: SCA Challenge Flow
+
+**Standard Flow (Qonto-style):**
+
+```
+1. Client → API: POST /transfers (initiate payment)
+2. API → Client: 428 Precondition Required
+   {
+     "error": "sca_required",
+     "sca_session_token": "sca_abc123",
+     "challenge_type": "paired_device",
+     "expires_in": 900
+   }
+3. API → User Device: Push notification "Approve €500 to Supplier GmbH"
+4. User → Device: Approve (biometric/PIN)
+5. Device → API: POST /sca/confirm (device confirms approval)
+6. Client polls: GET /sca/status/{token} → "approved"
+7. Client → API: POST /transfers (retry with X-Qonto-Sca-Session-Token)
+8. API → Client: 200 OK (transfer executed)
+```
+
+### FR-2: SCA Methods
+
+| Method | Factor Types | Priority | Description |
+|--------|--------------|----------|-------------|
+| `paired_device` | Possession + Inherence | 1 | Push to enrolled mobile app |
+| `passkey` | Possession + Inherence | 2 | WebAuthn/FIDO2 |
+| `totp` | Possession | 3 | Time-based OTP (authenticator app) |
+| `sms_otp` | Possession | 4 | SMS code (fallback only) |
+| `email_otp` | Possession | 5 | Email code (lowest security) |
+
+**Method Selection:**
+
+```go
+func (s *SCAService) SelectMethod(ctx context.Context, userID id.UserID, preference string) (SCAMethod, error) {
+    enrolled := s.getEnrolledMethods(ctx, userID)
+
+    // Honor preference if enrolled
+    if preference != "" && enrolled.Has(preference) {
+        return preference, nil
+    }
+
+    // Return highest-priority enrolled method
+    for _, method := range methodPriority {
+        if enrolled.Has(method) {
+            return method, nil
+        }
+    }
+
+    return "", ErrNoSCAMethodEnrolled
+}
+```
+
+### FR-3: Initiate SCA Challenge
+
+**Endpoint:** `POST /sca/challenge`
+
+**Description:** Initiate an SCA challenge for a sensitive action.
+
+**Input:**
+
+```json
+{
+  "action_type": "transfer",
+  "action_id": "txn_xyz789",
+  "action_data": {
+    "amount": 500,
+    "currency": "EUR",
+    "beneficiary_name": "Supplier GmbH",
+    "beneficiary_iban": "DE89..."
+  },
+  "method_preference": "paired_device"
+}
+```
+
+**Output (Success - 201):**
+
+```json
+{
+  "sca_session_token": "sca_abc123def456",
+  "challenge_type": "paired_device",
+  "status": "pending",
+  "expires_at": "2025-12-22T10:15:00Z",
+  "expires_in": 900,
+  "device_hint": "iPhone 14 Pro",
+  "action_summary": "Approve €500 transfer to Supplier GmbH"
+}
+```
+
+**Business Logic:**
+
+1. Validate user is authenticated
+2. Check if SCA is actually required (exemptions)
+3. Select SCA method based on preference/availability
+4. Generate unique `sca_session_token`
+5. Create challenge bound to action
+6. Store challenge with expiry (15 minutes)
+7. Trigger method-specific flow (push notification, etc.)
+8. Return challenge details
+
+### FR-4: SCA Challenge Status
+
+**Endpoint:** `GET /sca/status/{sca_session_token}`
+
+**Description:** Poll for SCA challenge status.
+
+**Output (Pending):**
+
+```json
+{
+  "sca_session_token": "sca_abc123def456",
+  "status": "pending",
+  "expires_at": "2025-12-22T10:15:00Z",
+  "method": "paired_device"
+}
+```
+
+**Output (Approved):**
+
+```json
+{
+  "sca_session_token": "sca_abc123def456",
+  "status": "approved",
+  "approved_at": "2025-12-22T10:05:30Z",
+  "method": "paired_device",
+  "valid_until": "2025-12-22T10:20:30Z"
+}
+```
+
+**Output (Denied/Expired):**
+
+```json
+{
+  "sca_session_token": "sca_abc123def456",
+  "status": "denied",
+  "reason": "user_rejected"
+}
+```
+
+### FR-5: Confirm SCA (Device Callback)
+
+**Endpoint:** `POST /sca/confirm`
+
+**Description:** Device confirms user approved the challenge.
+
+**Input:**
+
+```json
+{
+  "sca_session_token": "sca_abc123def456",
+  "device_id": "dev_xyz789",
+  "approval_signature": "eyJhbGciOiJFUzI1NiIs...",
+  "biometric_verified": true
+}
+```
+
+**Output (Success - 200):**
+
+```json
+{
+  "confirmed": true,
+  "valid_until": "2025-12-22T10:20:30Z"
+}
+```
+
+**Business Logic:**
+
+1. Validate device is paired to user
+2. Validate sca_session_token exists and is pending
+3. Validate approval signature (device private key)
+4. Mark challenge as approved
+5. Set validity window (5-15 minutes based on action type)
+6. Emit audit event `sca.challenge_approved`
+
+### FR-6: Validate SCA Token
+
+**Endpoint:** Internal service call
+
+**Description:** Validate SCA token for action execution.
+
+```go
+func (s *SCAService) ValidateSCAToken(ctx context.Context, token string, actionType string, actionID string) error {
+    challenge, err := s.store.FindByToken(ctx, token)
+    if err != nil {
+        return ErrInvalidSCAToken
+    }
+
+    if challenge.Status != ChallengeStatusApproved {
+        return ErrSCANotApproved
+    }
+
+    if time.Now().After(challenge.ValidUntil) {
+        return ErrSCATokenExpired
+    }
+
+    // Action binding: token must match the action it was issued for
+    if challenge.ActionType != actionType || challenge.ActionID != actionID {
+        return ErrSCATokenActionMismatch
+    }
+
+    // Single use: mark as used
+    challenge.UsedAt = time.Now()
+    s.store.Update(ctx, challenge)
+
+    return nil
+}
+```
+
+### FR-7: SCA Exemptions (PSD2 RTS)
+
+**Exemption Types:**
+
+| Exemption | Criteria | Max Amount |
+|-----------|----------|------------|
+| Low Value | Transaction amount | €30 (cumulative €100 or 5 txns) |
+| Trusted Beneficiary | Whitelisted recipient | Unlimited |
+| Recurring | Same amount/beneficiary | Per agreement |
+| Corporate | B2B dedicated processes | Per agreement |
+| TRA | Transaction Risk Analysis | Based on fraud rate |
+
+**Endpoint:** `POST /sca/exemptions/check`
+
+**Input:**
+
+```json
+{
+  "user_id": "user_abc123",
+  "action_type": "transfer",
+  "amount": 25,
+  "currency": "EUR",
+  "beneficiary_id": "ben_xyz789"
+}
+```
+
+**Output (Exempt):**
+
+```json
+{
+  "sca_required": false,
+  "exemption_type": "low_value",
+  "exemption_reason": "Transaction under €30 threshold",
+  "cumulative_remaining": 75
+}
+```
+
+**Output (Required):**
+
+```json
+{
+  "sca_required": true,
+  "reason": "amount_exceeds_threshold",
+  "required_method": "paired_device"
+}
+```
+
+### FR-8: Trusted Beneficiary Management
+
+**Endpoint:** `POST /sca/trusted-beneficiaries`
+
+**Description:** Add beneficiary to trusted list (requires SCA).
+
+**Input:**
+
+```json
+{
+  "beneficiary_id": "ben_xyz789",
+  "sca_session_token": "sca_abc123"
+}
+```
+
+**Output:**
+
+```json
+{
+  "trusted": true,
+  "beneficiary_id": "ben_xyz789",
+  "trusted_at": "2025-12-22T10:00:00Z"
+}
+```
+
+---
+
+## 4. Technical Requirements
+
+### TR-1: Data Models
+
+```go
+// internal/sca/models.go
+
+type SCAChallenge struct {
+    ID              id.ChallengeID
+    Token           string            // sca_session_token
+    UserID          id.UserID
+    TenantID        id.TenantID
+    Method          SCAMethod
+    Status          ChallengeStatus   // pending, approved, denied, expired
+    ActionType      string            // transfer, beneficiary_add, etc.
+    ActionID        string            // Transaction/action identifier
+    ActionDigest    string            // SHA-256 of action data
+    ActionSummary   string            // Human-readable summary
+    DeviceID        *string           // Paired device used for approval
+    CreatedAt       time.Time
+    ExpiresAt       time.Time
+    ApprovedAt      *time.Time
+    ValidUntil      *time.Time        // Token validity after approval
+    UsedAt          *time.Time        // When token was consumed
+    DeniedAt        *time.Time
+    DeniedReason    *string
+}
+
+type ChallengeStatus string
+
+const (
+    ChallengeStatusPending  ChallengeStatus = "pending"
+    ChallengeStatusApproved ChallengeStatus = "approved"
+    ChallengeStatusDenied   ChallengeStatus = "denied"
+    ChallengeStatusExpired  ChallengeStatus = "expired"
+    ChallengeStatusUsed     ChallengeStatus = "used"
+)
+
+type SCAMethod string
+
+const (
+    SCAMethodPairedDevice SCAMethod = "paired_device"
+    SCAMethodPasskey      SCAMethod = "passkey"
+    SCAMethodTOTP         SCAMethod = "totp"
+    SCAMethodSMSOTP       SCAMethod = "sms_otp"
+    SCAMethodEmailOTP     SCAMethod = "email_otp"
+    SCAMethodMock         SCAMethod = "mock"  // Sandbox only
+)
+
+type SCAExemption struct {
+    ID            id.ExemptionID
+    UserID        id.UserID
+    TenantID      id.TenantID
+    Type          ExemptionType
+    BeneficiaryID *id.BeneficiaryID  // For trusted beneficiary
+    MaxAmount     *int64
+    Currency      *string
+    ValidUntil    *time.Time         // For recurring agreements
+    CreatedAt     time.Time
+}
+
+type ExemptionType string
+
+const (
+    ExemptionLowValue          ExemptionType = "low_value"
+    ExemptionTrustedBeneficiary ExemptionType = "trusted_beneficiary"
+    ExemptionRecurring         ExemptionType = "recurring"
+    ExemptionCorporate         ExemptionType = "corporate"
+    ExemptionTRA               ExemptionType = "tra"
+)
+
+type LowValueTracker struct {
+    UserID       id.UserID
+    TenantID     id.TenantID
+    Date         string      // YYYY-MM-DD
+    TotalAmount  int64       // Cumulative amount
+    TxnCount     int         // Transaction count
+}
+```
+
+### TR-2: Store Interfaces
+
+```go
+type SCAStore interface {
+    // Challenges
+    SaveChallenge(ctx context.Context, challenge *SCAChallenge) error
+    FindChallengeByToken(ctx context.Context, token string) (*SCAChallenge, error)
+    FindChallengeByID(ctx context.Context, id id.ChallengeID) (*SCAChallenge, error)
+    UpdateChallenge(ctx context.Context, challenge *SCAChallenge) error
+    ExpirePending(ctx context.Context) (int, error)
+
+    // Exemptions
+    SaveExemption(ctx context.Context, exemption *SCAExemption) error
+    FindExemptionsByUser(ctx context.Context, userID id.UserID) ([]SCAExemption, error)
+    FindTrustedBeneficiary(ctx context.Context, userID id.UserID, beneficiaryID id.BeneficiaryID) (*SCAExemption, error)
+    DeleteExemption(ctx context.Context, id id.ExemptionID) error
+
+    // Low value tracking
+    GetLowValueTracker(ctx context.Context, userID id.UserID, date string) (*LowValueTracker, error)
+    IncrementLowValue(ctx context.Context, userID id.UserID, amount int64) error
+}
+```
+
+### TR-3: Service Layer
+
+```go
+type SCAService struct {
+    store         SCAStore
+    devices       DeviceStore         // PRD-001 device binding
+    notifications NotificationService // PRD-018
+    auditor       audit.Publisher
+    config        SCAConfig
+}
+
+// Challenge lifecycle
+func (s *SCAService) InitiateChallenge(ctx context.Context, req InitiateChallengeRequest) (*SCAChallenge, error)
+func (s *SCAService) GetChallengeStatus(ctx context.Context, token string) (*SCAChallenge, error)
+func (s *SCAService) ConfirmChallenge(ctx context.Context, req ConfirmChallengeRequest) error
+func (s *SCAService) DenyChallenge(ctx context.Context, token string, reason string) error
+func (s *SCAService) ValidateToken(ctx context.Context, token string, actionType string, actionID string) error
+
+// Exemptions
+func (s *SCAService) CheckExemption(ctx context.Context, req CheckExemptionRequest) (*ExemptionResult, error)
+func (s *SCAService) AddTrustedBeneficiary(ctx context.Context, userID id.UserID, beneficiaryID id.BeneficiaryID) error
+func (s *SCAService) RemoveTrustedBeneficiary(ctx context.Context, userID id.UserID, beneficiaryID id.BeneficiaryID) error
+
+// Method management
+func (s *SCAService) GetEnrolledMethods(ctx context.Context, userID id.UserID) ([]SCAMethod, error)
+func (s *SCAService) SelectMethod(ctx context.Context, userID id.UserID, preference string) (SCAMethod, error)
+```
+
+### TR-4: HTTP Middleware for SCA-Protected Endpoints
+
+```go
+func RequireSCA(scaService *SCAService, actionType string) func(http.Handler) http.Handler {
+    return func(next http.Handler) http.Handler {
+        return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+            userID := getUserID(r.Context())
+
+            // Check for SCA token in header
+            scaToken := r.Header.Get("X-Sca-Session-Token")
+
+            if scaToken == "" {
+                // Check exemptions first
+                actionData := extractActionData(r)
+                exempt, err := scaService.CheckExemption(r.Context(), CheckExemptionRequest{
+                    UserID:     userID,
+                    ActionType: actionType,
+                    ActionData: actionData,
+                })
+
+                if err == nil && !exempt.SCARequired {
+                    // Exempt, continue without SCA
+                    next.ServeHTTP(w, r)
+                    return
+                }
+
+                // SCA required, initiate challenge
+                challenge, _ := scaService.InitiateChallenge(r.Context(), InitiateChallengeRequest{
+                    UserID:     userID,
+                    ActionType: actionType,
+                    ActionData: actionData,
+                })
+
+                // Return 428 Precondition Required
+                w.Header().Set("Content-Type", "application/json")
+                w.WriteHeader(http.StatusPreconditionRequired)
+                json.NewEncoder(w).Encode(map[string]interface{}{
+                    "error":             "sca_required",
+                    "sca_session_token": challenge.Token,
+                    "challenge_type":    challenge.Method,
+                    "expires_in":        int(time.Until(challenge.ExpiresAt).Seconds()),
+                })
+                return
+            }
+
+            // Validate SCA token
+            actionID := extractActionID(r)
+            if err := scaService.ValidateToken(r.Context(), scaToken, actionType, actionID); err != nil {
+                http.Error(w, "Invalid or expired SCA token", http.StatusUnauthorized)
+                return
+            }
+
+            // SCA validated, proceed
+            next.ServeHTTP(w, r)
+        })
+    }
+}
+```
+
+### TR-5: Push Notification Integration
+
+```go
+type PairedDeviceNotifier struct {
+    pushService PushService
+}
+
+func (n *PairedDeviceNotifier) SendChallenge(ctx context.Context, challenge *SCAChallenge, device *Device) error {
+    return n.pushService.Send(ctx, PushNotification{
+        DeviceToken: device.PushToken,
+        Title:       "Approval Required",
+        Body:        challenge.ActionSummary,
+        Data: map[string]string{
+            "type":              "sca_challenge",
+            "sca_session_token": challenge.Token,
+            "action_type":       challenge.ActionType,
+            "action_digest":     challenge.ActionDigest,
+            "expires_at":        challenge.ExpiresAt.Format(time.RFC3339),
+        },
+        Priority: "high",
+        TTL:      int(time.Until(challenge.ExpiresAt).Seconds()),
+    })
+}
+```
+
+---
+
+## 5. API Specifications
+
+| Endpoint | Method | Auth | Purpose |
+|----------|--------|------|---------|
+| `/sca/challenge` | POST | Bearer | Initiate SCA challenge |
+| `/sca/status/{token}` | GET | Bearer | Get challenge status |
+| `/sca/confirm` | POST | Device | Device confirms approval |
+| `/sca/deny` | POST | Bearer/Device | User denies challenge |
+| `/sca/exemptions/check` | POST | Service | Check if SCA exempt |
+| `/sca/trusted-beneficiaries` | GET | Bearer | List trusted beneficiaries |
+| `/sca/trusted-beneficiaries` | POST | Bearer+SCA | Add trusted beneficiary |
+| `/sca/trusted-beneficiaries/{id}` | DELETE | Bearer+SCA | Remove trusted beneficiary |
+| `/sca/methods` | GET | Bearer | Get enrolled SCA methods |
+
+---
+
+## 6. Security Requirements
+
+### SR-1: Token Security
+- SCA tokens cryptographically random (256 bits)
+- Tokens single-use (consumed on validation)
+- Tokens action-bound (cannot be reused for different action)
+- Short expiry (15 minutes for challenge, 5 minutes after approval)
+
+### SR-2: Challenge Binding
+- Challenge includes action digest (SHA-256)
+- Device approval must sign the action digest
+- Mismatched digest = rejection
+
+### SR-3: Method Security
+- SMS OTP only as fallback (lower priority)
+- Paired device requires biometric/PIN on device
+- Rate limit challenge initiations (max 5 per hour)
+
+### SR-4: Exemption Security
+- Low value cumulative tracking (reset daily)
+- Trusted beneficiary addition requires SCA
+- Exemption abuse triggers risk review
+
+---
+
+## 7. Observability
+
+### Metrics
+
+```
+# Counter: SCA challenges by method and outcome
+sca_challenges_total{method, outcome="approved|denied|expired"}
+
+# Histogram: Time to approve
+sca_approval_duration_seconds{method}
+
+# Counter: SCA exemptions applied
+sca_exemptions_applied_total{type}
+
+# Counter: SCA tokens validated
+sca_tokens_validated_total{result="valid|invalid|expired|mismatch"}
+
+# Gauge: Pending challenges
+sca_challenges_pending
+```
+
+### Audit Events
+
+- `sca.challenge_initiated` - Challenge created
+- `sca.challenge_approved` - User approved
+- `sca.challenge_denied` - User denied
+- `sca.challenge_expired` - Challenge timed out
+- `sca.token_validated` - Token used for action
+- `sca.token_rejected` - Token validation failed
+- `sca.exemption_applied` - Action exempt from SCA
+- `sca.trusted_beneficiary_added` - New trusted beneficiary
+- `sca.trusted_beneficiary_removed` - Removed trusted beneficiary
+
+---
+
+## 8. Acceptance Criteria
+
+- [ ] 428 response returned when SCA required
+- [ ] Challenge token returned with expiry
+- [ ] Push notification sent to paired device
+- [ ] Device can approve/deny challenge
+- [ ] Polling endpoint shows challenge status
+- [ ] Action retry with valid token succeeds
+- [ ] Token rejected if action doesn't match
+- [ ] Token rejected after expiry
+- [ ] Token single-use (second use rejected)
+- [ ] Low value exemption works with cumulative tracking
+- [ ] Trusted beneficiary exemption works
+- [ ] Adding trusted beneficiary requires SCA
+- [ ] Audit trail complete for all SCA operations
+
+---
+
+## 9. Implementation Steps
+
+### Phase 1: Challenge Flow (6-8 hours)
+1. Challenge domain models
+2. Store implementation
+3. Initiate/Status/Confirm endpoints
+4. Token generation and validation
+5. Unit tests
+
+### Phase 2: Device Integration (4-6 hours)
+1. Push notification for paired device
+2. Device confirmation endpoint
+3. Approval signature verification
+4. Integration with PRD-001 device binding
+
+### Phase 3: Exemptions (3-4 hours)
+1. Exemption models and store
+2. Low value tracking
+3. Trusted beneficiary management
+4. Exemption check endpoint
+
+### Phase 4: Middleware & Integration (3-4 hours)
+1. RequireSCA middleware
+2. 428 response handling
+3. Action binding validation
+4. Integration tests
+
+### Phase 5: Sandbox Support (2 hours)
+1. Mock SCA method for sandbox
+2. Auto-approve option
+3. Testing documentation
+
+---
+
+## 10. Future Enhancements
+
+- WebAuthn/Passkey integration
+- Hardware token support (YubiKey)
+- SCA analytics dashboard
+- Adaptive SCA (risk-based method selection)
+- SCA delegation (approve on behalf of)
+- Batch approval (multiple actions, one SCA)
+- Offline approval (time-based approval codes)
+
+---
+
+## 11. References
+
+- [PSD2 RTS on Strong Customer Authentication](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32018R0389)
+- [EBA Opinion on SCA Elements](https://www.eba.europa.eu/regulation-and-policy/payment-services-and-electronic-money)
+- [Qonto SCA Documentation](https://docs.qonto.com/api-reference/business-api/authentication/sca/sca-flows)
+- PRD-021: Multi-Factor Authentication
+- PRD-027: Risk-Based Adaptive Authentication
+
+---
+
+## Revision History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2025-12-22 | Engineering | Initial PRD |

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -147,6 +147,22 @@ Credo is a **regulated identity and authorization system** that:
 
 ---
 
+### Phase 8: Banking Identity Pack (Fintech/Banking) - P1
+
+| PRD                                                         | Feature                              | Status         | Est. Time | Dependencies          |
+| ----------------------------------------------------------- | ------------------------------------ | -------------- | --------- | --------------------- |
+| [PRD-039](./PRD-039-SCA-Orchestration.md) 🆕                | SCA Orchestration (PSD2)             | 🔵 Not Started | 14-18h    | PRD-001, 021, 018     |
+| [PRD-035](./PRD-035-Identity-Assurance-Levels.md) 🆕        | Identity Assurance Levels            | 🔵 Not Started | 10-14h    | PRD-004, 003          |
+| [PRD-036](./PRD-036-Legal-Entity-Identity.md) 🆕            | Legal Entity Identity & Representation| 🔵 Not Started | 14-18h    | PRD-026A, 035         |
+| [PRD-037](./PRD-037-Multi-Party-Authorization.md) 🆕        | Multi-Party Authorization            | 🔵 Not Started | 18-22h    | PRD-036, 021, 039     |
+| [PRD-038](./PRD-038-Delegated-Authority.md) 🆕              | Delegated Authority (Power of Attorney)| 🔵 Not Started | 12-16h   | PRD-036, 037          |
+
+**Phase 8 Total:** ~68-88 hours (8.5-11 days)
+
+> **Note:** Phase 8 is designed for fintech/banking use cases. PRD-039 (SCA) is the foundation and can start after Phase 3. Other PRDs build on it progressively. This pack enables Credo to serve as an identity gateway for business banking platforms like Qonto.
+
+---
+
 ## Timeline Summary
 
 | Phase | Description     | PRDs                  | Time   | Cumulative   | Milestone             |
@@ -158,9 +174,10 @@ Credo is a **regulated identity and authorization system** that:
 | 4     | Assurance       | 13, 23, 6B, 7B, 8, 24 | 60-84h | 185-249h     | Regulated Ready       |
 | 5     | Decentralized   | 4B, 9, 10             | 46-58h | 231-307h     | Web3 Features         |
 | 6     | Integrations    | 11, 12, 14, 25, 26    | 46-64h | 277-371h     | Full Platform         |
-| 7     | Differentiation | 29, 30, 31, 32, 33    | 70-92h | **347-463h** | **Strategic Edge** 🎯 |
+| 7     | Differentiation | 29, 30, 31, 32, 33    | 70-92h | 347-463h     | Strategic Edge        |
+| 8     | Banking Identity| 35, 36, 37, 38, 39    | 68-88h | **415-551h** | **Banking Gateway** 🏦|
 
-**Total System Time:** ~347-463 hours (43-58 days)
+**Total System Time:** ~415-551 hours (52-69 days)
 
 ---
 
@@ -316,6 +333,15 @@ See [PRD-020: Storage Infrastructure Transition](./PRD-020-Operational-Readiness
 - Trust Score, Privacy Analytics, and Trust Network require Phase 5's ZKP foundation
 - These features differentiate Credo from Auth0/Okta/Keycloak
 
+**Phase 8 (Banking Identity):** Fintech/Banking-specific features (8.5-11 days)
+
+- SCA Orchestration (PRD-039) is the PSD2-compliant step-up auth foundation
+- Identity Assurance Levels (PRD-035) enables tiered KYC for transaction limits
+- Legal Entity Identity (PRD-036) models companies, directors, and signatories
+- Multi-Party Authorization (PRD-037) implements maker-checker and M-of-N approvals
+- Delegated Authority (PRD-038) enables vacation coverage and power-of-attorney patterns
+- These features position Credo as an identity gateway for business banking (Qonto-style)
+
 ### Module Bundle Alignment
 
 Module bundles organize PRDs by deployment scenario:
@@ -326,6 +352,7 @@ Module bundles organize PRDs by deployment scenario:
 - **Decentralized Pack:** Phase 5 (Web3)
 - **Integrations Pack:** Phase 6 (ecosystem)
 - **Differentiation Pack:** Phase 7 (strategic positioning)
+- **Banking Identity Pack:** Phase 8 (fintech/banking)
 
 See [ROADMAP.md](../ROADMAP.md#module-adoption-guide) for detailed bundle compositions.
 


### PR DESCRIPTION
Add five new PRDs for banking/fintech identity gateway features:

- PRD-035: Identity Assurance Levels (eIDAS-aligned IAL0-IAL3) Tracks identity proofing strength and enables tiered KYC

- PRD-036: Legal Entity Identity & Representation Models companies, directors, signatories with powers/constraints

- PRD-037: Multi-Party Authorization (Maker-Checker) M-of-N approval rules with cryptographic non-repudiation

- PRD-038: Delegated Authority (Power of Attorney) User-to-user delegation with scoped powers and constraints

- PRD-039: SCA Orchestration (PSD2 Compliance) 428 challenge flow for step-up auth (Qonto API-style)

These features position Credo as an identity gateway for business banking platforms without handling actual payments or financial data.