### PR TITLE
refactor(registry): improve architecture and add O(1) LRU cache

### DIFF
--- a/docs/openapi/registry.yaml
+++ b/docs/openapi/registry.yaml
@@ -77,12 +77,14 @@ paths:
                     date_of_birth: "1990-05-15"
                     address: "123 Main Street, Springfield, IL 62701"
                     valid: true
+                    source: "Mock Citizen Registry"
                     checked_at: "2025-12-11T10:00:00Z"
                 regulated_mode:
                   summary: Regulated mode (minimized data)
                   value:
                     national_id: "CITIZEN123456"
                     valid: true
+                    source: "Mock Citizen Registry"
                     checked_at: "2025-12-11T10:00:00Z"
                 invalid_record:
                   summary: Invalid/inactive citizen record
@@ -92,6 +94,17 @@ paths:
                     date_of_birth: "1985-01-01"
                     address: ""
                     valid: false
+                    source: "Mock Citizen Registry"
+                    checked_at: "2025-12-11T10:00:00Z"
+                fallback_provider:
+                  summary: Record from fallback provider
+                  value:
+                    national_id: "FALLBACK123"
+                    full_name: "Jane Smith"
+                    date_of_birth: "1992-03-20"
+                    address: "456 Oak Avenue, Chicago, IL 60601"
+                    valid: true
+                    source: "Fallback Citizen Registry"
                     checked_at: "2025-12-11T10:00:00Z"
 
         "400":
@@ -103,8 +116,14 @@ paths:
         "403":
           $ref: "#/components/responses/MissingConsent"
 
+        "404":
+          $ref: "#/components/responses/NotFound"
+
         "500":
           $ref: "#/components/responses/InternalError"
+
+        "503":
+          $ref: "#/components/responses/RegistryUnavailable"
 
         "504":
           $ref: "#/components/responses/RegistryTimeout"
@@ -171,8 +190,14 @@ paths:
         "403":
           $ref: "#/components/responses/MissingConsent"
 
+        "404":
+          $ref: "#/components/responses/NotFound"
+
         "500":
           $ref: "#/components/responses/InternalError"
+
+        "503":
+          $ref: "#/components/responses/RegistryUnavailable"
 
         "504":
           $ref: "#/components/responses/RegistryTimeout"
@@ -204,7 +229,7 @@ components:
 
     CitizenRecord:
       type: object
-      required: [national_id, valid, checked_at]
+      required: [national_id, valid, source, checked_at]
       properties:
         national_id:
           type: string
@@ -229,6 +254,11 @@ components:
           type: boolean
           description: Whether the citizen record is valid and active
           example: true
+        source:
+          type: string
+          description: Provider/registry that returned this record (useful for fallback scenarios)
+          maxLength: 255
+          example: "Mock Citizen Registry"
         checked_at:
           type: string
           format: date-time
@@ -240,6 +270,7 @@ components:
         date_of_birth: "1990-05-15"
         address: "123 Main Street, Springfield, IL 62701"
         valid: true
+        source: "Mock Citizen Registry"
         checked_at: "2025-12-11T10:00:00Z"
 
     SanctionsCheckRequest:
@@ -301,6 +332,7 @@ components:
             - policy_violation
             - internal_error
             - registry_timeout
+            - registry_unavailable
         error_description:
           type: string
           description: Human-readable error explanation
@@ -387,6 +419,37 @@ components:
                 error: internal_error
                 error_description: "Failed to store registry response in cache"
 
+    NotFound:
+      description: Requested record does not exist in the registry
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          examples:
+            citizen_not_found:
+              summary: Citizen record not found
+              value:
+                error: not_found
+                error_description: "Citizen record not found in registry"
+
+    RegistryUnavailable:
+      description: All registry providers are unavailable
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          examples:
+            all_providers_failed:
+              summary: All registry providers failed
+              value:
+                error: registry_unavailable
+                error_description: "All registry providers are unavailable"
+            primary_and_fallback_failed:
+              summary: Primary and fallback providers failed
+              value:
+                error: registry_unavailable
+                error_description: "Registry service temporarily unavailable"
+
     RegistryTimeout:
       description: External registry did not respond within timeout window
       content:
@@ -419,6 +482,7 @@ components:
         date_of_birth: "1990-05-15"
         address: "123 Main Street, Springfield, IL 62701"
         valid: true
+        source: "Mock Citizen Registry"
         checked_at: "2025-12-11T10:00:00Z"
 
     CitizenLookupRegulated:
@@ -426,6 +490,7 @@ components:
       value:
         national_id: "CITIZEN123456"
         valid: true
+        source: "Mock Citizen Registry"
         checked_at: "2025-12-11T10:00:00Z"
 
     SanctionsNotListed:

--- a/internal/evidence/registry/models/models.go
+++ b/internal/evidence/registry/models/models.go
@@ -10,6 +10,7 @@ type CitizenRecord struct {
 	DateOfBirth string
 	Address     string
 	Valid       bool
+	Source      string
 	CheckedAt   time.Time
 }
 

--- a/internal/evidence/registry/service/converter.go
+++ b/internal/evidence/registry/service/converter.go
@@ -108,6 +108,7 @@ func CitizenVerificationToRecord(cv citizen.CitizenVerification) *models.Citizen
 		DateOfBirth: cv.DateOfBirth(),
 		Address:     cv.Address(),
 		Valid:       cv.IsValid(),
+		Source:      cv.ProviderID().String(),
 		CheckedAt:   cv.CheckedAt().Time(),
 	}
 }

--- a/internal/evidence/registry/store/store_memory_test.go
+++ b/internal/evidence/registry/store/store_memory_test.go
@@ -96,8 +96,8 @@ func (s *InMemoryCacheSuite) TestSaveCitizen() {
 
 		s.Require().NoError(err1)
 		s.Require().NoError(err2)
-		s.True(found1.Valid)   // First record
-		s.False(found2.Valid)  // Second record - different!
+		s.True(found1.Valid)  // First record
+		s.False(found2.Valid) // Second record - different!
 	})
 
 	s.Run("handles concurrent saves without race conditions", func() {
@@ -378,39 +378,6 @@ func (s *InMemoryCacheSuite) TestEviction() {
 		// KEYABC1 should be evicted
 		_, err := cache.FindSanction(ctx, makeKey(1))
 		s.ErrorIs(err, ErrNotFound)
-	})
-}
-
-func (s *InMemoryCacheSuite) TestCleanupExpired() {
-	ctx := context.Background()
-
-	s.Run("removes expired entries from both caches", func() {
-		cache := NewInMemoryCache(10 * time.Millisecond)
-
-		key1 := testNationalID("KEYABC1")
-		key2 := testNationalID("KEYABC2")
-
-		citizenRecord := &models.CitizenRecord{NationalID: "KEYABC1", Valid: true, CheckedAt: time.Now()}
-		sanctionRecord := &models.SanctionsRecord{NationalID: "KEYABC2", Listed: true, CheckedAt: time.Now()}
-
-		_ = cache.SaveCitizen(ctx, key1, citizenRecord, false)
-		_ = cache.SaveSanction(ctx, key2, sanctionRecord)
-
-		// Verify they exist
-		citizens, sanctions := cache.Size()
-		s.Equal(1, citizens)
-		s.Equal(1, sanctions)
-
-		// Wait for expiration
-		time.Sleep(15 * time.Millisecond)
-
-		// Run cleanup
-		cache.CleanupExpired()
-
-		// Verify they're gone
-		citizens, sanctions = cache.Size()
-		s.Equal(0, citizens)
-		s.Equal(0, sanctions)
 	})
 }
 


### PR DESCRIPTION
This pull request introduces several improvements and new features to the registry integration, focusing on better traceability of data sources, enhanced OpenAPI documentation, improved error handling, and internal codebase refactoring for maintainability and clarity.

**OpenAPI and API Response Enhancements:**

- Added a new `source` field to the `CitizenRecord` schema and all related API responses, making it explicit which provider returned a given citizen record (useful for fallback and multi-provider scenarios). This is now a required property. [[1]](diffhunk://#diff-5d70a470a95f11816204185551108f1d3f6232126ccb537eea86f85bd8038ca3R80-R87) [[2]](diffhunk://#diff-5d70a470a95f11816204185551108f1d3f6232126ccb537eea86f85bd8038ca3L207-R232) [[3]](diffhunk://#diff-5d70a470a95f11816204185551108f1d3f6232126ccb537eea86f85bd8038ca3R257-R261) [[4]](diffhunk://#diff-5d70a470a95f11816204185551108f1d3f6232126ccb537eea86f85bd8038ca3R273) [[5]](diffhunk://#diff-5d70a470a95f11816204185551108f1d3f6232126ccb537eea86f85bd8038ca3R485-R493) [[6]](diffhunk://#diff-5cc3a404d5e097ff3450ea6a0f9e538b92cac7b3f840a72556c83a025a1e4499R13) [[7]](diffhunk://#diff-8c3a355f6dd28d7f21244f64d9b9b151d510a56410eb6da7b84c67a2366dc140R111)
- Expanded API error handling: added new `404 Not Found` and `503 RegistryUnavailable` responses to the OpenAPI spec, with detailed example payloads for each. [[1]](diffhunk://#diff-5d70a470a95f11816204185551108f1d3f6232126ccb537eea86f85bd8038ca3R119-R127) [[2]](diffhunk://#diff-5d70a470a95f11816204185551108f1d3f6232126ccb537eea86f85bd8038ca3R193-R201) [[3]](diffhunk://#diff-5d70a470a95f11816204185551108f1d3f6232126ccb537eea86f85bd8038ca3R422-R452)
- Added example for fallback provider response in OpenAPI and e2e tests, ensuring clarity on how fallback scenarios are handled and documented.

**Backend Refactoring and Domain-Driven Improvements:**

- Refactored request validation for both citizen and sanctions lookups: parsed domain primitives are now stored and reused, preventing double parsing and clarifying handler logic. [[1]](diffhunk://#diff-5488a4466df75b8e94edbd339c2bd6bf0c111366579aa58cf21e58a89c58be76R64-R122) [[2]](diffhunk://#diff-5488a4466df75b8e94edbd339c2bd6bf0c111366579aa58cf21e58a89c58be76L125-R150) [[3]](diffhunk://#diff-5488a4466df75b8e94edbd339c2bd6bf0c111366579aa58cf21e58a89c58be76L182-R211)
- Moved audit logic for sanctions checks out of the HTTP handler and into the service layer, following hexagonal architecture principles. The handler now only maps service errors to HTTP responses. [[1]](diffhunk://#diff-5488a4466df75b8e94edbd339c2bd6bf0c111366579aa58cf21e58a89c58be76L182-R211) [[2]](diffhunk://#diff-5488a4466df75b8e94edbd339c2bd6bf0c111366579aa58cf21e58a89c58be76L198-L203) [[3]](diffhunk://#diff-9dcda226c19b023d3b3042cfbd43ffccc4b4b8faee3be2a5a80f5b7d24583662R1-R15) [[4]](diffhunk://#diff-2733d1e888cc7387381dba34d68d06300741ff3ff3f92612e509f7eda379d032R22-R23)

**Testing and Documentation:**

- Updated and expanded end-to-end tests to cover the new `source` field, fallback provider behavior, and new error scenarios (404 for not found, 503 for all providers unavailable, etc.). [[1]](diffhunk://#diff-02d7c15d0447d05d11cb5b2eafba3838150f300707f687987d20c3e1599991faR20-R24) [[2]](diffhunk://#diff-02d7c15d0447d05d11cb5b2eafba3838150f300707f687987d20c3e1599991faR149-R162) [[3]](diffhunk://#diff-02d7c15d0447d05d11cb5b2eafba3838150f300707f687987d20c3e1599991faL223-R239)
- Updated handler tests to reflect the audit logic refactor, ensuring correct error mapping and response structure. [[1]](diffhunk://#diff-51fbd9c80052d6ceca1490012d94cc5dd6e145864454e6a92292b844a1211bfaL180-L226) [[2]](diffhunk://#diff-51fbd9c80052d6ceca1490012d94cc5dd6e145864454e6a92292b844a1211bfaR274)

**Summary of Most Important Changes:**

**API schema and documentation improvements:**
- Added `source` as a required field in `CitizenRecord` and all related API responses and OpenAPI examples, ensuring traceability of which provider returned each record. [[1]](diffhunk://#diff-5d70a470a95f11816204185551108f1d3f6232126ccb537eea86f85bd8038ca3L207-R232) [[2]](diffhunk://#diff-5d70a470a95f11816204185551108f1d3f6232126ccb537eea86f85bd8038ca3R257-R261) [[3]](diffhunk://#diff-5d70a470a95f11816204185551108f1d3f6232126ccb537eea86f85bd8038ca3R273) [[4]](diffhunk://#diff-5d70a470a95f11816204185551108f1d3f6232126ccb537eea86f85bd8038ca3R485-R493) [[5]](diffhunk://#diff-5cc3a404d5e097ff3450ea6a0f9e538b92cac7b3f840a72556c83a025a1e4499R13) [[6]](diffhunk://#diff-8c3a355f6dd28d7f21244f64d9b9b151d510a56410eb6da7b84c67a2366dc140R111)
- Enhanced OpenAPI spec with new error responses: `404 Not Found` and `503 RegistryUnavailable`, including example payloads for each. [[1]](diffhunk://#diff-5d70a470a95f11816204185551108f1d3f6232126ccb537eea86f85bd8038ca3R119-R127) [[2]](diffhunk://#diff-5d70a470a95f11816204185551108f1d3f6232126ccb537eea86f85bd8038ca3R193-R201) [[3]](diffhunk://#diff-5d70a470a95f11816204185551108f1d3f6232126ccb537eea86f85bd8038ca3R422-R452)
- Documented fallback provider scenarios in API examples and e2e tests. [[1]](diffhunk://#diff-5d70a470a95f11816204185551108f1d3f6232126ccb537eea86f85bd8038ca3R97-R107) [[2]](diffhunk://#diff-02d7c15d0447d05d11cb5b2eafba3838150f300707f687987d20c3e1599991faL223-R239)

**Backend and architectural changes:**
- Refactored request validation to parse and store domain primitives (`NationalID`) once, exposing them via accessor methods for handler use. [[1]](diffhunk://#diff-5488a4466df75b8e94edbd339c2bd6bf0c111366579aa58cf21e58a89c58be76R64-R122) [[2]](diffhunk://#diff-5488a4466df75b8e94edbd339c2bd6bf0c111366579aa58cf21e58a89c58be76L125-R150) [[3]](diffhunk://#diff-5488a4466df75b8e94edbd339c2bd6bf0c111366579aa58cf21e58a89c58be76L182-R211)
- Moved audit event logic for sanctions checks from the HTTP handler to the service layer, aligning with hexagonal architecture and improving separation of concerns. [[1]](diffhunk://#diff-5488a4466df75b8e94edbd339c2bd6bf0c111366579aa58cf21e58a89c58be76L182-R211) [[2]](diffhunk://#diff-5488a4466df75b8e94edbd339c2bd6bf0c111366579aa58cf21e58a89c58be76L198-L203) [[3]](diffhunk://#diff-9dcda226c19b023d3b3042cfbd43ffccc4b4b8faee3be2a5a80f5b7d24583662R1-R15) [[4]](diffhunk://#diff-2733d1e888cc7387381dba34d68d06300741ff3ff3f92612e509f7eda379d032R22-R23)

**Testing updates:**
- Expanded e2e and handler tests to verify new fields, fallback logic, and error scenarios. [[1]](diffhunk://#diff-02d7c15d0447d05d11cb5b2eafba3838150f300707f687987d20c3e1599991faR20-R24) [[2]](diffhunk://#diff-02d7c15d0447d05d11cb5b2eafba3838150f300707f687987d20c3e1599991faR149-R162) [[3]](diffhunk://#diff-02d7c15d0447d05d11cb5b2eafba3838150f300707f687987d20c3e1599991faL223-R239) [[4]](diffhunk://#diff-51fbd9c80052d6ceca1490012d94cc5dd6e145864454e6a92292b844a1211bfaL180-L226)
