### PR TITLE
llm(credo): document pointer preference, Execute callback, and TOCTOU…

### DIFF
--- a/.claude/commands/ddd-review.md
+++ b/.claude/commands/ddd-review.md
@@ -11,8 +11,9 @@ Keep the model sharp: clear aggregates, invariants, domain primitives, clean orc
 See AGENTS.md shared non-negotiables, plus these DDD-specific rules:
 
 - Services own orchestration; domain owns rules and decisions.
-- Stores return domain models (not persistence structs).
+- Stores return domain models as pointers (not persistence structs, not copies).
 - Domain entities do not contain API input/transport rules.
+- **Service/store error boundary**: Stores return sentinel errors only (`ErrNotFound`, etc.); services own domain errors. Use Execute callback pattern for atomic validate-then-mutate to avoid error boomerangs.
 - **Domain layer is pure:**
   - No I/O: no database, no HTTP, no filesystem.
   - No `context.Context` in domain function signatures.
@@ -153,6 +154,14 @@ if token.IsExpiredAt(s.clock.Now()) { ... }
 - Is this the simplest solution that works?
 - Does the recommendation leverage existing library types (`uuid.UUID`, stdlib)?
 - Will tests guard the invariant? If yes, prefer tests over defensive code.
+
+### Pointer vs value types
+
+- **Prefer pointer returns** (`*Entity`) from stores and services to avoid struct copying.
+- Use value types only when:
+  - Immutability is required (value objects that should never change after creation)
+  - Mutation of the original would be a bug (e.g., returning a copy to prevent caller modification)
+- Small value objects (IDs, enums, timestamps) are fine as values.
 
 ## Import rule enforcement
 

--- a/.claude/commands/secure-design-agent.md
+++ b/.claude/commands/secure-design-agent.md
@@ -33,6 +33,7 @@ See AGENTS.md shared non-negotiables, plus these security-specific rules:
 - Identity/token/session/consent/authorization lifecycles (replay, confusion, bypass risks)
 - Authority propagation across modules/services
 - Error + failure modeling (safe client messages, stable codes, internal detail preserved only in logs)
+- TOCTOU prevention via atomic Execute callback pattern (validate and mutate under same lock)
 - Tests that lock in security behaviors/invariants (not brittle implementation tests)
 
 ## What I do
@@ -57,7 +58,7 @@ See AGENTS.md shared non-negotiables, plus these security-specific rules:
 - Any panic-based factories or MustX in production?
 - Any errors leaking internals or user-provided content?
 - Are auth decisions explicit, centralized, and testable?
-- Any TOCTOU races between check and use (authz, file existence, quota/capacity checks)?
+- Any TOCTOU races between check and use (authz, file existence, quota/capacity checks)? Use Execute callback pattern for atomic validate-then-mutate.
 - Any partial writes without transactions for multi-step invariants?
 - Any lifecycle gaps: replay, double-submit, state confusion, missing revocation/expiry checks?
 - Is the approach idiomatic Go (stdlib errors, `errors.Is/As`, `%w`, leverage uuid/sql/json behavior)?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,8 @@ All review agents inherit these rules. Individual agents should not repeat them;
 6. **Atomic multi-write operations** — no partial writes; use transactions/RunInTx.
 7. **Prefer type aliases + Parse\* over struct wrappers for IDs** — e.g., `type UserID uuid.UUID`.
 8. **Interfaces at consumer site** — only when 2+ implementations or a hard boundary exists.
+9. **Prefer pointer returns for domain models** — avoid copying structs; use values only when immutability is required or mutation risk exists.
+10. **Service/store error boundary** — stores return sentinel errors only; services own domain errors. Use Execute callback pattern to avoid TOCTOU races and error boomerangs (domain→sentinel→domain translation).
 
 ## When to use which agent
 


### PR DESCRIPTION
… prevention

Add coding rules and agent guidance for:
- Prefer pointer returns for domain models (avoid struct copying)
- Service/store error boundary with Execute callback pattern
- TOCTOU prevention via atomic validate-then-mutate under lock
- Error boomerang anti-pattern and its fix

Updates CLAUDE.md, AGENTS.md, and agent command files (balance-review, ddd-review, secure-design-agent) to reflect patterns established in commit 4ac142f.

🤖 Generated with [Claude Code](https://claude.com/claude-code)