### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
 
   integration:
     name: Integration Tests (Testcontainers)
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/abramin/Credo/security/code-scanning/10](https://github.com/abramin/Credo/security/code-scanning/10)

To fix this, we should explicitly restrict `GITHUB_TOKEN` permissions for the `integration` job to the minimum required. The job performs only read-only operations on the repository (checkout, dependency download, tests), so `contents: read` is sufficient.

The best fix without changing functionality is:

- Add a `permissions` block under the `integration` job, parallel to `name` and `runs-on`, setting `contents: read`.
- Leave other jobs unchanged, since `e2e` already has a `permissions` block and `test` is not flagged; we’ll address only what CodeQL reported.

Concretely, in `.github/workflows/ci.yml`, edit the `integration` job definition around line 50 to insert:

```yaml
  integration:
    name: Integration Tests (Testcontainers)
    permissions:
      contents: read
    runs-on: ubuntu-latest
```

No additional imports or methods are needed; it’s purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
